### PR TITLE
time format edit

### DIFF
--- a/ewdm/sources.py
+++ b/ewdm/sources.py
@@ -59,11 +59,25 @@ class SpotterBuoysDataSource(object):
         data = pd.read_csv(
             self.fname, names=columns, header=None, skiprows=1
         )
-        # combine the desired date-time columns and convert them to datetime
+
+
+        # Format the 'msec' column to be three digits
+        data['msec'] = data['msec'].apply(lambda x: f'{int(x):03}')
+        # print(data['msec'])
+
+        # Combine the desired date-time columns and convert them to datetime
+        # Here, we concatenate the time components and ensure the millisecond part is correctly formatted
         data["time"] = pd.to_datetime(
-            data[columns[:7]].astype(str).agg(','.join, axis=1),
-            format="%Y,%m,%d,%H,%M,%S,%f"
+            data['year'].astype(str) + '-' +
+            data['month'].astype(str) + '-' +
+            data['day'].astype(str) + ' ' +
+            data['hour'].astype(str) + ':' +
+            data['min'].astype(str) + ':' +
+            data['sec'].astype(str) + '.' +
+            data['msec'],  # Concatenate using three-digit milliseconds
+            format="%Y-%m-%d %H:%M:%S.%f"  # Use .%f to parse the millisecond part
         )
+
         data = data.drop(columns=columns[:7])
 
         # convert to xarray and add metadata


### PR DESCRIPTION
I encountered this issue while using the program to process Datawell's Waverider raw format data. Since the sampling rate is 1.28 Hz, the millisecond (msec) values sometimes appear as 93, but the program interprets this as 930, which is incorrect and causes problems with time conversion. This leads to errors in the time sequence, as the program expects the time to be monotonically increasing. Here's an example of the data:

```
#year   month   day   hour   min   sec   msec   x (m)   y (m)   z (m)
2024    7       15    23     3     14    531    0.04    -0.09   -0.05
2024    7       15    23     3     15    312    -0.06   -0.06   -0.08
2024    7       15    23     3     16    **93**     -0.11   0.03    -0.02
2024    7       15    23     3     16    875    -0.09   0.15    0.02
2024    7       15    23     3     17    656    -0.03   0.12    0.07
```

Since the time is not strictly increasing, the program raises an error.

Change as:
```
        # Format the 'msec' column to be three digits
        data['msec'] = data['msec'].apply(lambda x: f'{int(x):03}')
        # print(data['msec'])

        # Combine the desired date-time columns and convert them to datetime
        # Here, we concatenate the time components and ensure the millisecond part is correctly formatted
        data["time"] = pd.to_datetime(
            data['year'].astype(str) + '-' +
            data['month'].astype(str) + '-' +
            data['day'].astype(str) + ' ' +
            data['hour'].astype(str) + ':' +
            data['min'].astype(str) + ':' +
            data['sec'].astype(str) + '.' +
            data['msec'],  # Concatenate using three-digit milliseconds
            format="%Y-%m-%d %H:%M:%S.%f"  # Use .%f to parse the millisecond part
        )
```