### PR TITLE
Fix numpy 2.0 compatibility:

### DIFF
--- a/ewdm/density.py
+++ b/ewdm/density.py
@@ -9,6 +9,11 @@ import logging
 
 from .parameters import VARIABLE_NAMES
 
+# numpy 2.0 renamed `np.trapz` to `np.trapezoid` and removed the old
+# name. Use the new name when available and fall back on older numpy.
+_trapezoid = getattr(np, "trapezoid", getattr(np, "trapz", None))
+
+
 # von mises kernel desnsity estimation
 def _vonmises_kde(arr, bins, kappa):
     """Return Kernel-Density Estimation using von Mises distribution"""
@@ -20,7 +25,7 @@ def _vonmises_kde(arr, bins, kappa):
     kde = (
         np.exp(kappa * np.cos(x)).sum(axis=1) / (2 * np.pi * np.i0(kappa))
     )
-    kde /= np.trapz(kde, x=bins)
+    kde /= _trapezoid(kde, x=bins)
     return kde
 
 


### PR DESCRIPTION
np.trapz was removed in numpy 2.0 (renamed to np.trapezoid). The von Mises KDE in density.py called it directly, which raised AttributeError on numpy >= 2.0 for any call that estimates a spectrum. Use np.trapezoid when available and fall back to np.trapz on older numpy.