### PR TITLE
Feature/wavenumber-invphasespeed-spectra

### DIFF
--- a/ewdm/density.py
+++ b/ewdm/density.py
@@ -91,3 +91,211 @@ def estimate_directional_distribution(power, theta, dd, kappa):
 
     return output_ds
 
+
+# kernel density estimation along a radial (non-periodic) axis {{{
+def _gaussian_radial_kde(arr, bins, bandwidth="silverman"):
+    """Return Gaussian Kernel-Density Estimation along a radial axis.
+
+    Unlike the directional case, the radial coordinate (wavenumber or
+    inverse phase speed) is not periodic, so a plain Gaussian kernel is
+    used instead of the von Mises kernel. The estimate is normalised so
+    that it integrates to unity over `bins`.
+
+    Args:
+        arr (np.ndarray): Sample values along the radial axis.
+        bins (np.ndarray): Radial bin centers where the density is
+            evaluated.
+        bandwidth (str or float): Either a number giving the kernel
+            bandwidth or the string ``silverman`` to use Silverman's
+            rule of thumb (default).
+
+    Returns:
+        np.ndarray: Normalised density evaluated at `bins`.
+    """
+
+    if bandwidth == "silverman":
+        bandwidth = 1.06 * arr.std() * len(arr) ** (-1. / 5.)
+
+    # the Silverman bandwidth collapses to zero when the radial samples
+    # have little or no spread (e.g. a near-monochromatic sea state). In
+    # that case the Gaussian kernel becomes a delta function that misses
+    # the discrete `bins` grid, so we floor the bandwidth at the local
+    # bin spacing to keep the kernel resolvable.
+    bin_spacing = np.median(np.diff(bins)) if len(bins) > 1 else 1.0
+    bandwidth = max(bandwidth, bin_spacing)
+
+    # guard against a degenerate (zero-spread) sample
+    if bandwidth == 0 or not np.isfinite(bandwidth):
+        return np.zeros_like(bins, dtype="float")
+
+    x = (bins[:, None] - arr[None, :]) / bandwidth
+    fac = 1 / np.sqrt(2 * np.pi)
+    kde = (fac * np.exp(-0.5 * x**2)).sum(axis=1) / (len(arr) * bandwidth)
+
+    # normalise to unit integral over the radial bins. np.trapezoid was
+    # introduced in numpy 2.0 as the replacement for np.trapz; fall back
+    # to the old name on numpy 1.x.
+    _trapz = getattr(np, "trapezoid", getattr(np, "trapz", None))
+    area = _trapz(kde, x=bins)
+    if area > 0:
+        kde /= area
+    return kde
+
+
+# function to get radial density along the frequency axis
+def _get_radial_density(arr, bins, bandwidth):
+    if np.isnan(arr).all():
+        return np.zeros_like(bins, dtype="float") * np.nan
+    else:
+        return _gaussian_radial_kde(arr[~np.isnan(arr)], bins=bins,
+                                    bandwidth=bandwidth)
+# }}}
+
+
+# estimate spectrum on a (radial, direction) grid {{{
+def estimate_radial_distribution(
+        power, theta, radial, radial_name, bins_radial,
+        dd, kappa, bandwidth="silverman"
+    ):
+    """Construct a directional spectrum on a (radial, direction) grid.
+
+    This is the wavenumber/inverse-phase-speed analogue of
+    :func:`estimate_directional_distribution`. The energy contained in
+    each frequency band, ``S(f) = <power>_t``, is redistributed onto a
+    radial axis (wavenumber ``k`` or inverse phase speed ``nu = k /
+    omega``, following Björkqvist et al., 2019) according to the local
+    radial estimates obtained per ``(frequency, time)`` sample, and onto
+    the directional axis using the same von Mises kernel as the
+    frequency-direction path. The mapping conserves variance, i.e.
+    ``sum E(r, theta) dr dtheta == sum S(f) df`` up to the discretisation
+    of the kernels.
+
+    Args:
+        power (xr.DataArray): Wavelet power with dims ``(frequency,
+            time)``, identical to the array used by
+            :func:`estimate_directional_distribution`.
+        theta (xr.DataArray): Local wave direction in degrees with dims
+            ``(frequency, time)``.
+        radial (xr.DataArray): Local radial coordinate (e.g. wavenumber
+            in rad/m, or inverse phase speed ``nu`` in s/m) with dims
+            ``(frequency, time)``.
+        radial_name (str): Name of the radial coordinate. It must be a
+            key in :data:`ewdm.parameters.VARIABLE_NAMES` and is used to
+            label the output dimension and the radial spectrum. For
+            ``nu`` the radial spectrum follows the ``Q(nu)`` convention
+            of Björkqvist et al. (2019).
+        bins_radial (np.ndarray): Bin centres for the radial axis.
+        dd (float): Directional resolution in degrees.
+        kappa (float): Smoothness parameter for the von Mises kernel used
+            along the directional axis.
+        bandwidth (str or float): Bandwidth for the Gaussian kernel used
+            along the radial axis. Default is Silverman's rule.
+
+    Returns:
+        xr.Dataset: Dataset containing the directional spectrum
+        ``directional_spectrum`` on the ``(radial_name, direction)``
+        grid, the radial spectrum ``<radial_name>_spectrum`` (``Q`` when
+        ``radial_name == "nu"``), and the directional distribution
+        ``directional_distribution``.
+    """
+
+    # directional and radial bin arrays
+    bins_dir = np.arange(-180, 180, dd)
+
+    # directional distribution function D(f, theta), reusing the von
+    # Mises kernel of the frequency-direction path
+    D = np.apply_along_axis(
+        _get_density, arr=np.asarray(theta), bins=bins_dir,
+        kappa=kappa, axis=1
+    )
+
+    # radial distribution function R(f, r) using a Gaussian kernel along
+    # the non-periodic radial axis
+    R = np.apply_along_axis(
+        _get_radial_density, arr=np.asarray(radial), bins=bins_radial,
+        bandwidth=bandwidth, axis=1
+    )
+
+    # average wavelet power per frequency, S(f). This is the same
+    # quantity used by the frequency-direction path, so the absolute
+    # scaling is inherited unchanged.
+    S = power.mean("time").data
+
+    # total variance per frequency band, S(f) df. Summed over frequency
+    # this equals the sea surface variance (m0).
+    df = np.gradient(power["frequency"].data)
+    Sdf = S * df
+
+    # Energy density on the (radial, direction) grid. D is a density that
+    # integrates to one over direction in *degrees* (sum D dd == 1) and R
+    # integrates to one over the radial axis (int R dr == 1). Hence
+    #     rho(r, theta) = sum_f S(f) df R(f, r) D(f, theta)
+    # satisfies  sum_r sum_theta rho dr dd == sum_f S df == m0, i.e. it
+    # conserves the total variance.
+    rho = np.einsum("f,fr,fd->rd", Sdf, R, D)
+
+    # Omnidirectional radial spectrum, F(k) (m^3) or Q(nu) (m^3/s),
+    # following Björkqvist et al. (2019). Integrating the energy density
+    # over direction recovers the omnidirectional spectrum such that
+    # int F(k) dk == int Q(nu) dnu == m0. This is equivalent to their
+    # Eqs. (6) and (11), int Psi(r, theta) r dtheta, once the radial
+    # Jacobian is reintroduced below.
+    radial_spectrum = rho.sum(axis=1) * dd
+
+    # Directional spectrum following the polar convention of Björkqvist
+    # et al. (2019, Eqs. 6 and 11), in which the radial Jacobian is
+    # factored out of the *directional* spectrum:
+    #     Psi(k, theta)    [m^4/rad]      with  F(k)  = int Psi k dtheta
+    #     Q_dir(nu, theta) [m^4/(s^2 rad)] with Q(nu) = int Q_dir nu dtheta
+    # We convert the degree-based density to a per-radian density and
+    # divide by the radial coordinate, guarding against r = 0.
+    r = bins_radial.astype("float")
+    r_safe = np.where(r == 0, np.nan, r)
+    deg_per_rad = 180.0 / np.pi
+    directional_spectrum = (rho * deg_per_rad) / r_safe[:, None]
+
+    # return dataset
+    output_ds = xr.Dataset(
+        data_vars = {
+            "directional_spectrum": (
+                [radial_name, "direction"], directional_spectrum
+            ),
+            "directional_distribution": (
+                ["frequency", "direction"], D
+            ),
+            f"{radial_name}_spectrum": ([radial_name], radial_spectrum),
+        },
+        coords = {
+            "frequency": power["frequency"].data,
+            radial_name: bins_radial,
+            "direction": bins_dir,
+        }
+    )
+    for coord in ("frequency", "direction", radial_name):
+        if coord in VARIABLE_NAMES:
+            output_ds[coord].attrs = VARIABLE_NAMES[coord]
+    for var in output_ds.data_vars:
+        if var in VARIABLE_NAMES:
+            output_ds[var].attrs = VARIABLE_NAMES[var]
+
+    # The directional spectrum carries coordinate-specific units in the
+    # polar convention of Björkqvist et al. (2019): Psi(k, theta) is in
+    # m^4/rad and Q_dir(nu, theta) is in m^4/(s^2 rad). Override the
+    # generic metadata accordingly.
+    _dir_units = {
+        "wavenumber": "m^4/rad",
+        "nu": "m^4/(s^2 rad)",
+    }
+    if radial_name in _dir_units:
+        output_ds["directional_spectrum"].attrs = {
+            "standard_name": f"sea_surface_{radial_name}_directional_wave_spectrum",
+            "long_name": (
+                "Directional wavenumber wave spectrum Psi(k, theta)"
+                if radial_name == "wavenumber"
+                else "Directional inverse-phase-speed wave spectrum Q(nu, theta)"
+            ),
+            "units": _dir_units[radial_name],
+        }
+
+    return output_ds
+# }}}

--- a/ewdm/density.py
+++ b/ewdm/density.py
@@ -93,7 +93,7 @@ def estimate_directional_distribution(power, theta, dd, kappa):
 
 
 # kernel density estimation along a radial (non-periodic) axis {{{
-def _gaussian_radial_kde(arr, bins, bandwidth="silverman"):
+def _gaussian_radial_kde(arr, bins, bandwidth="silverman", bandwidth_floor=None):
     """Return Gaussian Kernel-Density Estimation along a radial axis.
 
     Unlike the directional case, the radial coordinate (wavenumber or
@@ -108,6 +108,16 @@ def _gaussian_radial_kde(arr, bins, bandwidth="silverman"):
         bandwidth (str or float): Either a number giving the kernel
             bandwidth or the string ``silverman`` to use Silverman's
             rule of thumb (default).
+        bandwidth_floor (float, optional): Optional physical lower bound on
+            the kernel bandwidth, in the units of the radial coordinate.
+            When given, the bandwidth is never allowed to fall below this
+            value. Intended for callers who want to impose a known
+            resolution limit; note this should be a *kernel width*, not an
+            aperture wavelength such as ``2*pi / L_baseline`` (which is far
+            wider than a sensible kernel and over-smooths). If None, the
+            data-driven (Silverman) bandwidth is used and only floored at
+            the local bin spacing to keep the kernel resolvable for
+            degenerate, near-zero-spread samples.
 
     Returns:
         np.ndarray: Normalised density evaluated at `bins`.
@@ -119,10 +129,16 @@ def _gaussian_radial_kde(arr, bins, bandwidth="silverman"):
     # the Silverman bandwidth collapses to zero when the radial samples
     # have little or no spread (e.g. a near-monochromatic sea state). In
     # that case the Gaussian kernel becomes a delta function that misses
-    # the discrete `bins` grid, so we floor the bandwidth at the local
-    # bin spacing to keep the kernel resolvable.
-    bin_spacing = np.median(np.diff(bins)) if len(bins) > 1 else 1.0
-    bandwidth = max(bandwidth, bin_spacing)
+    # the discrete `bins` grid. We floor the bandwidth so the kernel stays
+    # resolvable. An explicit `bandwidth_floor` (a kernel width) may be
+    # supplied by the caller to impose a known resolution limit; otherwise
+    # we fall back to the local bin spacing, which keeps the kernel
+    # resolvable without biasing the well-sampled, broadband case.
+    if bandwidth_floor is not None and np.isfinite(bandwidth_floor):
+        bandwidth = max(bandwidth, float(bandwidth_floor))
+    else:
+        bin_spacing = np.median(np.diff(bins)) if len(bins) > 1 else 1.0
+        bandwidth = max(bandwidth, bin_spacing)
 
     # guard against a degenerate (zero-spread) sample
     if bandwidth == 0 or not np.isfinite(bandwidth):
@@ -143,19 +159,20 @@ def _gaussian_radial_kde(arr, bins, bandwidth="silverman"):
 
 
 # function to get radial density along the frequency axis
-def _get_radial_density(arr, bins, bandwidth):
+def _get_radial_density(arr, bins, bandwidth, bandwidth_floor=None):
     if np.isnan(arr).all():
         return np.zeros_like(bins, dtype="float") * np.nan
     else:
         return _gaussian_radial_kde(arr[~np.isnan(arr)], bins=bins,
-                                    bandwidth=bandwidth)
+                                    bandwidth=bandwidth,
+                                    bandwidth_floor=bandwidth_floor)
 # }}}
 
 
 # estimate spectrum on a (radial, direction) grid {{{
 def estimate_radial_distribution(
         power, theta, radial, radial_name, bins_radial,
-        dd, kappa, bandwidth="silverman"
+        dd, kappa, bandwidth="silverman", bandwidth_floor=None
     ):
     """Construct a directional spectrum on a (radial, direction) grid.
 
@@ -190,6 +207,12 @@ def estimate_radial_distribution(
             along the directional axis.
         bandwidth (str or float): Bandwidth for the Gaussian kernel used
             along the radial axis. Default is Silverman's rule.
+        bandwidth_floor (float, optional): Physical lower bound on the
+            radial-kernel bandwidth (e.g. the array wavenumber resolution
+            ``2*pi / L_baseline`` for wavenumber, or its slowness
+            equivalent for ``nu``). Prevents the smoothed spectrum from
+            implying structure finer than the array can resolve. When
+            None, the kernel is floored at the local bin spacing instead.
 
     Returns:
         xr.Dataset: Dataset containing the directional spectrum
@@ -213,7 +236,7 @@ def estimate_radial_distribution(
     # the non-periodic radial axis
     R = np.apply_along_axis(
         _get_radial_density, arr=np.asarray(radial), bins=bins_radial,
-        bandwidth=bandwidth, axis=1
+        bandwidth=bandwidth, bandwidth_floor=bandwidth_floor, axis=1
     )
 
     # average wavelet power per frequency, S(f). This is the same

--- a/ewdm/main.py
+++ b/ewdm/main.py
@@ -9,7 +9,7 @@ import logging
 from tqdm import tqdm
 
 from .wavelets import cwt, xwt
-from .density import estimate_directional_distribution
+from .density import estimate_directional_distribution, estimate_radial_distribution
 from .helpers import get_sampling_frequency
 from .sources import SpotterBuoysDataSource, CDIPDataSourceRealTime
 from .parameters import VARIABLE_NAMES
@@ -425,16 +425,57 @@ class Arrays(_BaseClass):
             coords={"frequency": self.freqs, "time": _dataset["time"]},
         )
 
+        # local wavenumber magnitude k = |(kx, ky)| in rad/m. This is
+        # solved from the spatial phase gradients and is therefore an
+        # observed quantity, independent of any dispersion assumption.
+        wavenumber = xr.DataArray(
+            np.hypot(kx, ky),
+            dims = ["frequency", "time"],
+            coords={"frequency": self.freqs, "time": _dataset["time"]},
+        )
+
+        # local inverse phase speed nu = k / omega = k / (2 pi f),
+        # following Björkqvist et al. (2019), in s/m.
+        omega = 2 * np.pi * self.freqs
+        nu = wavenumber / xr.DataArray(
+            omega, dims=["frequency"], coords={"frequency": self.freqs}
+        )
+
         # compute wavelet power from wavelet coefficients
         data_std = _dataset["surface_elevation"].std("time")
         power = np.abs(coeffs) ** 2
         if self.normalise:
             wavelet_energy = power.mean("time").integrate("frequency")**0.5
             mean_power = (power * data_std / wavelet_energy).mean("element")
-        
-        return estimate_directional_distribution(
-            mean_power, theta, dd=self.dd, kappa=self.kappa
-        )
+        else:
+            mean_power = power.mean("element")
+
+        # frequency-direction spectrum (default, unchanged behaviour)
+        if self.coordinate in ("frequency", None):
+            return estimate_directional_distribution(
+                mean_power, theta, dd=self.dd, kappa=self.kappa
+            )
+
+        # wavenumber-direction or inverse-phase-speed-direction spectrum
+        elif self.coordinate == "wavenumber":
+            return estimate_radial_distribution(
+                mean_power, theta, wavenumber, "wavenumber",
+                bins_radial=self.bins_radial,
+                dd=self.dd, kappa=self.kappa, bandwidth=self.bandwidth
+            )
+
+        elif self.coordinate == "nu":
+            return estimate_radial_distribution(
+                mean_power, theta, nu, "nu",
+                bins_radial=self.bins_radial,
+                dd=self.dd, kappa=self.kappa, bandwidth=self.bandwidth
+            )
+
+        else:
+            raise Exception(
+                "`coordinate` should be either `frequency`, "
+                "`wavenumber` or `nu`."
+            )
 
 
     def compute(
@@ -449,6 +490,9 @@ class Arrays(_BaseClass):
             kappa: float = 36.0,
             use: str = "displacements",
             block_size: str = "30min",
+            coordinate: str = "frequency",
+            bins_radial: np.ndarray = None,
+            bandwidth: str = "silverman",
         ) -> xr.Dataset:
         """Perform computation using specified parameters.
 
@@ -483,6 +527,21 @@ class Arrays(_BaseClass):
                 computation over each block. The resulting output will have a
                 time dimension. It is advisable to choose values of no more than
                 half-hour. Default `block_size="30min"`.
+            coordinate (str, optional): Independent radial coordinate of the
+                output spectrum. One of `frequency` (default, the usual
+                frequency-direction spectrum), `wavenumber`, or `nu` (the
+                inverse phase speed nu = k / omega, yielding the Q(nu, theta)
+                spectrum of Björkqvist et al., 2019). The latter two are
+                available only for `Arrays` because they rely on the
+                wavenumber vector solved from the spatial phase gradients.
+            bins_radial (np.ndarray, optional): Bin centres for the radial
+                axis when `coordinate` is `wavenumber` (rad/m) or `nu`
+                (s/m). If None, a sensible range is derived from the data.
+                Ignored when `coordinate="frequency"`.
+            bandwidth (str or float, optional): Bandwidth for the Gaussian
+                kernel used along the radial axis. Either a number or the
+                string `silverman` (default). Ignored when
+                `coordinate="frequency"`.
 
         Returns:
             xr.Dataset: Dataset containing the directional spectrum, directional
@@ -512,6 +571,32 @@ class Arrays(_BaseClass):
         # data used for estimation
         self.use = use
         self.block_size = block_size
+
+        # radial coordinate of the output spectrum
+        self.coordinate = coordinate
+        self.bandwidth = bandwidth
+
+        # default radial bins if none are provided. The resolutions
+        # follow Björkqvist et al. (2019): dk = 1/12 rad/m and
+        # dnu = 1/50 s/m. The grids start one bin-width above zero so the
+        # polar directional spectrum (which carries a 1/r Jacobian) has no
+        # singular bin at the origin. The upper bounds follow the
+        # practical cutoffs used by Björkqvist et al. (2019), who binned
+        # the inverse phase speed spectrum only for k < 9 rad/m because of
+        # high noise near the Nyquist wavenumber. The corresponding nu
+        # cutoff is nu = k / omega evaluated at the lowest resolved
+        # frequency, which bounds the slowest (largest-nu) waves.
+        if bins_radial is None and coordinate == "wavenumber":
+            dk = 1.0 / 12.0
+            kmax = 9.0
+            self.bins_radial = np.arange(dk, kmax + dk, dk)
+        elif bins_radial is None and coordinate == "nu":
+            dnu = 1.0 / 50.0
+            nu_max = 9.0 / (2 * np.pi * self.freqs[0])
+            nu_max = min(nu_max, 2.0)  # cap at a physically reasonable slowness
+            self.bins_radial = np.arange(dnu, nu_max + dnu, dnu)
+        else:
+            self.bins_radial = bins_radial
 
         # determine length of time series
         # if dataset contains more than one hour of data, it will be splitted

--- a/ewdm/main.py
+++ b/ewdm/main.py
@@ -389,6 +389,18 @@ class Arrays(_BaseClass):
         # array geometry
         dx = self.array_geometry(_dataset)
 
+        # Largest baseline (maximum pairwise separation) of the array, in
+        # metres. The coarsest wavenumber the array can resolve is of order
+        # 2*pi / L_baseline. This is exposed as `self._L_baseline` so a
+        # caller can, if they wish, choose an explicit `bandwidth_floor`
+        # informed by the array geometry; it is not applied automatically,
+        # because an aperture wavelength is far wider than a sensible KDE
+        # kernel and would over-smooth the spectrum.
+        if dx.size:
+            self._L_baseline = float(np.max(np.hypot(dx[:, 0], dx[:, 1])))
+        else:
+            self._L_baseline = np.nan
+
         # TODO: add the following paramaters as class attrs
         # xmin = np.min(np.abs(dx[:, 0] + 1j*dx[:, 1]))
         # xmax = np.max(np.abs(dx[:, 0] + 1j*dx[:, 1]))
@@ -456,19 +468,29 @@ class Arrays(_BaseClass):
                 mean_power, theta, dd=self.dd, kappa=self.kappa
             )
 
-        # wavenumber-direction or inverse-phase-speed-direction spectrum
+        # wavenumber-direction or inverse-phase-speed-direction spectrum.
+        # The radial-KDE bandwidth is left to Silverman's data-driven rule
+        # (see `density._gaussian_radial_kde`), which together with the
+        # log-spaced default grid yields F(k)/Q(nu) spectra about as smooth
+        # as S(f) while keeping the spectral peak unbiased. An explicit
+        # `self.bandwidth_floor` (default None) is forwarded for callers who
+        # want to impose a physical lower bound on the kernel width; when
+        # None the kernel is only floored at the local bin spacing to guard
+        # against degenerate (zero-spread) radial samples.
         elif self.coordinate == "wavenumber":
             return estimate_radial_distribution(
                 mean_power, theta, wavenumber, "wavenumber",
                 bins_radial=self.bins_radial,
-                dd=self.dd, kappa=self.kappa, bandwidth=self.bandwidth
+                dd=self.dd, kappa=self.kappa, bandwidth=self.bandwidth,
+                bandwidth_floor=self.bandwidth_floor
             )
 
         elif self.coordinate == "nu":
             return estimate_radial_distribution(
                 mean_power, theta, nu, "nu",
                 bins_radial=self.bins_radial,
-                dd=self.dd, kappa=self.kappa, bandwidth=self.bandwidth
+                dd=self.dd, kappa=self.kappa, bandwidth=self.bandwidth,
+                bandwidth_floor=self.bandwidth_floor
             )
 
         else:
@@ -492,7 +514,9 @@ class Arrays(_BaseClass):
             block_size: str = "30min",
             coordinate: str = "frequency",
             bins_radial: np.ndarray = None,
+            bins_per_octave: int = 24,
             bandwidth: str = "silverman",
+            bandwidth_floor: float = None,
         ) -> xr.Dataset:
         """Perform computation using specified parameters.
 
@@ -538,10 +562,25 @@ class Arrays(_BaseClass):
                 axis when `coordinate` is `wavenumber` (rad/m) or `nu`
                 (s/m). If None, a sensible range is derived from the data.
                 Ignored when `coordinate="frequency"`.
+            bins_per_octave (int, optional): Number of bins per octave for
+                the default log-spaced radial grid used when `bins_radial`
+                is None (default 24). Logarithmic spacing matches the
+                wavelet frequency grid and yields smoother F(k)/Q(nu)
+                spectra. Ignored when `bins_radial` is supplied or when
+                `coordinate="frequency"`.
             bandwidth (str or float, optional): Bandwidth for the Gaussian
                 kernel used along the radial axis. Either a number or the
                 string `silverman` (default). Ignored when
                 `coordinate="frequency"`.
+            bandwidth_floor (float, optional): Physical lower bound on the
+                radial-kernel bandwidth, in the units of the radial
+                coordinate (rad/m for `wavenumber`, s/m for `nu`). Default
+                None, in which case Silverman's data-driven bandwidth is
+                used and only floored at the local bin spacing to guard
+                degenerate samples. Provide a value to impose a known
+                resolution limit (note the array baseline length is
+                available as `self._L_baseline` after `compute`). Ignored
+                when `coordinate="frequency"`.
 
         Returns:
             xr.Dataset: Dataset containing the directional spectrum, directional
@@ -575,26 +614,41 @@ class Arrays(_BaseClass):
         # radial coordinate of the output spectrum
         self.coordinate = coordinate
         self.bandwidth = bandwidth
+        self.bandwidth_floor = bandwidth_floor
 
-        # default radial bins if none are provided. The resolutions
-        # follow Björkqvist et al. (2019): dk = 1/12 rad/m and
-        # dnu = 1/50 s/m. The grids start one bin-width above zero so the
+        # number of bins per octave for the default (log-spaced) radial
+        # grids. Logarithmic spacing mirrors the wavelet frequency grid
+        # `self.freqs` (also log-uniform), placing bins where the spectral
+        # structure is and rendering smoothly on the usual log-log axes.
+        # `nperoct` only controls how finely the radial KDE is *sampled*;
+        # the physical reliability of the result is governed by the kernel
+        # bandwidth and its `bandwidth_floor` (see `compute_spectrum`), not
+        # by the bin count.
+        self.bins_per_octave = bins_per_octave
+
+        # default radial bins if none are provided. We keep the
+        # Björkqvist et al. (2019) span — wavenumber over roughly
+        # [1/12, 9] rad/m and inverse phase speed nu = k / omega bounded by
+        # the slowest resolved wave — but distribute the bins
+        # logarithmically rather than linearly so the omnidirectional F(k)
+        # and Q(nu) spectra look as smooth as the frequency spectrum S(f).
+        # The lower bound stays one Björkqvist bin-width above zero so the
         # polar directional spectrum (which carries a 1/r Jacobian) has no
-        # singular bin at the origin. The upper bounds follow the
-        # practical cutoffs used by Björkqvist et al. (2019), who binned
-        # the inverse phase speed spectrum only for k < 9 rad/m because of
-        # high noise near the Nyquist wavenumber. The corresponding nu
-        # cutoff is nu = k / omega evaluated at the lowest resolved
-        # frequency, which bounds the slowest (largest-nu) waves.
+        # singular bin at the origin.
+        def _logbins(lo, hi, nperoct):
+            noct = np.log2(hi / lo)
+            npts = int(np.ceil(nperoct * noct)) + 1
+            return 2.0 ** np.linspace(np.log2(lo), np.log2(hi), npts)
+
         if bins_radial is None and coordinate == "wavenumber":
-            dk = 1.0 / 12.0
-            kmax = 9.0
-            self.bins_radial = np.arange(dk, kmax + dk, dk)
+            k_lo = 1.0 / 12.0
+            k_hi = 9.0
+            self.bins_radial = _logbins(k_lo, k_hi, self.bins_per_octave)
         elif bins_radial is None and coordinate == "nu":
-            dnu = 1.0 / 50.0
-            nu_max = 9.0 / (2 * np.pi * self.freqs[0])
-            nu_max = min(nu_max, 2.0)  # cap at a physically reasonable slowness
-            self.bins_radial = np.arange(dnu, nu_max + dnu, dnu)
+            nu_lo = 1.0 / 50.0
+            nu_hi = 9.0 / (2 * np.pi * self.freqs[0])
+            nu_hi = min(nu_hi, 2.0)  # cap at a physically reasonable slowness
+            self.bins_radial = _logbins(nu_lo, nu_hi, self.bins_per_octave)
         else:
             self.bins_radial = bins_radial
 

--- a/ewdm/parameters.py
+++ b/ewdm/parameters.py
@@ -24,7 +24,7 @@ VARIABLE_NAMES = {
      },
      'frequency_spectrum': {
          'standard_name': 'sea_surface_frequency_wave_spectrum',
-         'long_name': 'Azimutally-integrated wave energy density spectrum',
+         'long_name': 'Azimuthally-integrated wave energy density spectrum',
          'units': 'm^2/Hz'
      },
      'directional_spectrum': {
@@ -36,6 +36,26 @@ VARIABLE_NAMES = {
          'standard_name': 'sea_surface_wave_directional_distribution_function',
          'long_name': 'Directional distribution function of wave energy',
          'units': 'dimensionless'
+     },
+     'wavenumber': {
+         'standard_name': 'sea_surface_wave_wavenumber',
+         'long_name': 'Wavenumber magnitude',
+         'units': 'rad/m'
+     },
+     'nu': {
+         'standard_name': 'sea_surface_wave_inverse_phase_speed',
+         'long_name': 'Inverse phase speed (nu = k / omega)',
+         'units': 's/m'
+     },
+     'wavenumber_spectrum': {
+         'standard_name': 'sea_surface_wavenumber_wave_spectrum',
+         'long_name': 'Omnidirectional wavenumber wave spectrum F(k)',
+         'units': 'm^3'
+     },
+     'nu_spectrum': {
+         'standard_name': 'sea_surface_inverse_phase_speed_wave_spectrum',
+         'long_name': 'Omnidirectional inverse-phase-speed wave spectrum Q(nu)',
+         'units': 'm^3/s'
      },
     'surface_elevation': {
         'standard_name': 'sea_surface_wave_elevation',

--- a/tests/test_radial_spectra.py
+++ b/tests/test_radial_spectra.py
@@ -158,3 +158,108 @@ def test_custom_radial_bins_respected():
         coordinate="wavenumber", bins_radial=bins, **COMMON
     )
     np.testing.assert_allclose(out["wavenumber"].values, bins)
+
+# ---------------------------------------------------------------------------
+# Smoother default radial binning (log-spaced grid + Silverman bandwidth).
+# These tests guard the binning behaviour introduced for smoother, but still
+# reliable, F(k) and Q(nu) spectra. They use the array fixture rather than a
+# pure monochromatic wave so the spectrum has a resolvable shape to smooth.
+# ---------------------------------------------------------------------------
+
+def _log_smoothness(spectrum):
+    """Mean absolute step in log-spectrum between adjacent positive bins.
+
+    A smaller value means a smoother curve on log axes. Used as a relative
+    smoothness metric (compare two spectra computed on grids of comparable
+    density), not as an absolute threshold.
+    """
+    y = np.asarray(spectrum, dtype=float)
+    y = y[y > 0]
+    if y.size < 3:
+        return np.nan
+    return float(np.mean(np.abs(np.diff(np.log(y)))))
+
+
+def test_default_radial_grid_is_log_spaced():
+    """The default wavenumber/nu grids should be logarithmically spaced."""
+    arr, _, _ = _monochromatic_array()
+    for coord in ("wavenumber", "nu"):
+        out = arr.compute(coordinate=coord, **COMMON)
+        r = out[coord].values
+        # On a log-uniform grid the ratio of successive bins is constant.
+        ratios = r[1:] / r[:-1]
+        assert np.allclose(ratios, ratios[0], rtol=1e-6), \
+            f"{coord} default grid is not log-spaced"
+        # ... and it should NOT be linear (constant difference).
+        diffs = np.diff(r)
+        assert not np.allclose(diffs, diffs[0], rtol=1e-3), \
+            f"{coord} default grid is still linear"
+
+
+def test_bins_per_octave_preserves_variance_and_peak():
+    """Refining bins_per_octave must not move the peak or change variance.
+
+    This encodes the design principle that bin density is only a rendering
+    lever: the spectral content is set by the kernel bandwidth, so variance
+    (m0) and the peak location must be invariant to bins_per_octave.
+    """
+    arr, _, _ = _monochromatic_array()
+    for coord, spec in [("wavenumber", "wavenumber_spectrum"),
+                        ("nu", "nu_spectrum")]:
+        m0, peaks = [], []
+        for npo in (12, 24, 48):
+            out = arr.compute(coordinate=coord, bins_per_octave=npo, **COMMON)
+            r = out[coord].values
+            S = out[spec].values
+            m0.append(_trapezoid(S, r))
+            peaks.append(r[np.nanargmax(S)])
+        # variance conserved across densities
+        assert np.allclose(m0, m0[0], rtol=1e-6), f"{coord}: m0 drifts with bins"
+        # peak stable to within a quarter octave
+        assert max(peaks) / min(peaks) < 2 ** 0.25, \
+            f"{coord}: peak moves with bins_per_octave"
+
+
+def test_log_grid_smoother_than_linear():
+    """The log-spaced default should be smoother than a comparable linear grid.
+
+    Using a broadband-ish array case, the log-spaced default grid should not
+    be rougher (in the mean |dlog S| sense) than an explicit linear grid of
+    similar bin count over the same span.
+    """
+    arr, k0, _ = _monochromatic_array()
+    out_log = arr.compute(coordinate="wavenumber", **COMMON)
+    r_log = out_log["wavenumber"].values
+
+    # comparable linear grid: same span, same number of bins
+    lin = np.linspace(r_log[0], r_log[-1], len(r_log))
+    out_lin = arr.compute(coordinate="wavenumber", bins_radial=lin, **COMMON)
+
+    s_log = _log_smoothness(out_log["wavenumber_spectrum"].values)
+    s_lin = _log_smoothness(out_lin["wavenumber_spectrum"].values)
+    # log grid should be at least as smooth (allow a small tolerance)
+    assert s_log <= s_lin * 1.05, \
+        f"log grid not smoother: log={s_log:.4f} linear={s_lin:.4f}"
+
+
+def test_bandwidth_floor_is_respected():
+    """An explicit bandwidth_floor should broaden (smooth) the spectrum.
+
+    Passing a large bandwidth_floor must not raise and must produce a
+    spectrum at least as smooth as the unfloored default, while still
+    conserving variance.
+    """
+    arr, _, _ = _monochromatic_array()
+    out_def = arr.compute(coordinate="wavenumber", **COMMON)
+    out_flr = arr.compute(coordinate="wavenumber", bandwidth_floor=0.5, **COMMON)
+
+    r = out_flr["wavenumber"].values
+    m0_def = _trapezoid(out_def["wavenumber_spectrum"].values,
+                        out_def["wavenumber"].values)
+    m0_flr = _trapezoid(out_flr["wavenumber_spectrum"].values, r)
+    # variance conserved regardless of the floor
+    assert np.isclose(m0_def, m0_flr, rtol=0.05)
+    # floored spectrum is at least as smooth
+    s_def = _log_smoothness(out_def["wavenumber_spectrum"].values)
+    s_flr = _log_smoothness(out_flr["wavenumber_spectrum"].values)
+    assert s_flr <= s_def * 1.05

--- a/tests/test_radial_spectra.py
+++ b/tests/test_radial_spectra.py
@@ -1,0 +1,160 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Copyright © 2024 Daniel Pelaez-Zapata <http://github.com/dspelaez>
+Distributed under terms of the GNU/GPL 3.0 license.
+
+Tests for the wavenumber and inverse-phase-speed (nu) directional
+spectra added to the `Arrays` class. The nu = k / omega convention and
+the Q(nu) spectrum follow Björkqvist et al. (2019).
+"""
+
+import numpy as np
+import pytest
+
+import ewdm
+from ewdm.density import estimate_radial_distribution
+
+# numpy 2.0 renamed np.trapz to np.trapezoid; support both in tests.
+_trapezoid = getattr(np, "trapezoid", getattr(np, "trapz", None))
+
+
+GRAV = 9.8
+
+
+def _monochromatic_array(f0=0.2, direction_deg=40.0, amplitude=0.5,
+                         fs=4.0, duration=600.0):
+    """Build an Arrays instance for a single plane wave.
+
+    Returns the Arrays instance together with the true wavenumber and
+    inverse phase speed (nu) so the tests can check the peak locations.
+    """
+    t = np.arange(0, duration, 1 / fs)
+    omega = 2 * np.pi * f0
+    k0 = omega**2 / GRAV               # deep-water dispersion
+    theta = np.radians(direction_deg)
+    kx0, ky0 = k0 * np.cos(theta), k0 * np.sin(theta)
+
+    # pentagon plus a centre point, small enough that k0 * d < pi
+    radius = 0.5 * (np.pi / k0) / 2
+    ang = np.radians(np.array([0, 72, 144, 216, 288]))
+    px = np.r_[0.0, radius * np.cos(ang)]
+    py = np.r_[0.0, radius * np.sin(ang)]
+
+    eta = np.stack(
+        [amplitude * np.cos(kx0*x + ky0*y - omega*t)
+         for x, y in zip(px, py)],
+        axis=-1
+    )
+
+    arr = ewdm.Arrays.from_numpy(
+        time=t, surface_elevation=eta,
+        position_x=px, position_y=py, fs=fs
+    )
+    return arr, k0, k0 / omega
+
+
+COMMON = dict(omin=-4, omax=1, nvoice=8, dd=5.0, kappa=100.0)
+
+
+def test_frequency_path_unchanged():
+    """The default coordinate should still return a frequency spectrum."""
+    arr, _, _ = _monochromatic_array()
+    out = arr.compute(coordinate="frequency", **COMMON)
+    assert "frequency_spectrum" in out
+    assert "frequency" in out.coords
+    assert out["directional_spectrum"].dims == ("frequency", "direction")
+
+
+def test_wavenumber_spectrum_peak():
+    """The wavenumber spectrum should peak near the true wavenumber."""
+    arr, k0, _ = _monochromatic_array()
+    out = arr.compute(coordinate="wavenumber", **COMMON)
+
+    assert out["directional_spectrum"].dims == ("wavenumber", "direction")
+    assert out["wavenumber"].attrs["units"] == "rad/m"
+    assert out["wavenumber_spectrum"].attrs["units"] == "m^3"
+    assert out["directional_spectrum"].attrs["units"] == "m^4/rad"
+
+    k = out["wavenumber"].values
+    Sk = out["wavenumber_spectrum"].values
+    k_peak = k[np.nanargmax(Sk)]
+    assert abs(k_peak - k0) / k0 < 0.25
+
+
+def test_nu_spectrum_peak():
+    """The nu (inverse phase speed) spectrum should peak near k0 / omega0."""
+    arr, _, nu0 = _monochromatic_array()
+    out = arr.compute(coordinate="nu", **COMMON)
+
+    assert out["directional_spectrum"].dims == ("nu", "direction")
+    assert out["nu"].attrs["units"] == "s/m"
+    assert out["nu_spectrum"].attrs["units"] == "m^3/s"
+    assert out["directional_spectrum"].attrs["units"] == "m^4/(s^2 rad)"
+
+    nu = out["nu"].values
+    Q = out["nu_spectrum"].values
+    nu_peak = nu[np.nanargmax(Q)]
+    assert abs(nu_peak - nu0) / nu0 < 0.3
+
+
+def test_variance_conserved_across_coordinates():
+    """Integrated energy should match across f, k and nu."""
+    arr, _, _ = _monochromatic_array()
+    out_f = arr.compute(coordinate="frequency", **COMMON)
+    out_k = arr.compute(coordinate="wavenumber", **COMMON)
+    out_nu = arr.compute(coordinate="nu", **COMMON)
+
+    var_f = _trapezoid(out_f["frequency_spectrum"].values,
+                       out_f["frequency"].values)
+    var_k = _trapezoid(out_k["wavenumber_spectrum"].values,
+                       out_k["wavenumber"].values)
+    var_nu = _trapezoid(out_nu["nu_spectrum"].values,
+                        out_nu["nu"].values)
+
+    assert np.isclose(var_f, var_k, rtol=0.15)
+    assert np.isclose(var_f, var_nu, rtol=0.15)
+
+
+def test_bjorkqvist_directional_integral_identity():
+    """Check Björkqvist et al. (2019) Eqs. (6) and (11):
+
+    F(k)  = int Psi(k, theta) k dtheta,
+    Q(nu) = int Q_dir(nu, theta) nu dtheta.
+
+    The omnidirectional spectrum must equal the directional spectrum
+    integrated over direction with the radial Jacobian.
+    """
+    arr, _, _ = _monochromatic_array()
+    dtheta = np.radians(COMMON["dd"])
+
+    for coord, spec in [("wavenumber", "wavenumber_spectrum"),
+                        ("nu", "nu_spectrum")]:
+        out = arr.compute(coordinate=coord, **COMMON)
+        Psi = out["directional_spectrum"].values     # (r, theta)
+        r = out[coord].values
+        F = out[spec].values
+        F_from_dir = np.nansum(Psi, axis=1) * r * dtheta
+
+        mask = F > 0.01 * np.nanmax(F)
+        rel = np.abs(F_from_dir[mask] - F[mask]) / F[mask]
+        assert np.nanmax(rel) < 1e-6, f"{coord}: identity violated"
+
+
+def test_invalid_coordinate_raises():
+    """An unknown coordinate should raise an informative error."""
+    arr, _, _ = _monochromatic_array()
+    with pytest.raises(Exception):
+        arr.compute(coordinate="nonsense", **COMMON)
+
+
+def test_custom_radial_bins_respected():
+    """User-supplied radial bins should appear as the output coordinate."""
+    arr, _, _ = _monochromatic_array()
+    bins = np.linspace(0.05, 0.5, 64)
+    out = arr.compute(
+        coordinate="wavenumber", bins_radial=bins, **COMMON
+    )
+    np.testing.assert_allclose(out["wavenumber"].values, bins)


### PR DESCRIPTION
Within this PR- Python versions of two WDM (original, Donelan _et al._, 1996) accompaniments written over the years in MATLAB:
* Mark's (I think? Maybe Will Drennan's; not sure) function _direction_wavenumber.m_, which produces a wavenumber-directional spectrum. The original used linearly-spaced wavenumber array for the binning, but I'm making the default a log-spaced wavenumber array to (1) more efficiently use the multi-decade space in _k_ and (2) follow the convention used for _f_.
-- **This yields $\Psi(k,\theta)$**
* Jan-Victor Björkqvist's function _direction_inverse_phase_speed.m_, which produces an inverse phase speed-directional spectrum. As with the wavenumber spectrum, this originally used a linearly-spaced independent variable for binning.
-- **This yields $Q(\nu,\theta)$**

I did **not** implement your TODO note from main.py: # TODO: restrict to residuals less than certain threshold. In my version of Donelan's MATLAB WDM code, the restriction was based on standard deviation of the mean across a particular set of wave staff pairs; perhaps this tweak could go into a future PR?

Here are the directional and omnidirectional spectra computed via ewdm.Arrays() from the Donelan "Run82" example used in the EWDM Gallery:

<img width="1999" height="1329" alt="run82_spectra_3coord" src="https://github.com/user-attachments/assets/83ffa5f3-4969-4297-960f-d846ed835452" />

... and the down-wave wavenumber-frequency directional spectrum, with linear and second harmonic overlaid:

<img width="872" height="804" alt="run82_dispersion_kw" src="https://github.com/user-attachments/assets/7d77df48-a234-493e-8bb0-4c9b33def87f" />

(1) Is this worthwhile for addition? I'm very interested in using this type of framework for
(2) Would it be worth expanding into a Gallery tab? The stereo-video data from Guimarães _et al._ (2020) is likely to be the most relevant for the average user. But the short record of that dataset is ~1.2 GB, so I figured I'd start with the bite-sized Donelan_run82 case.

One more note/demonstration from our ASIT 2019 field campaign: here are a set of 20 synthetic wave gauges seeded into a field of water surface elevation inferred from (1) my Extended Polarimetric Slope Sensing approach + (2) direct numerical integration of the surface slope field (Harker & O'Leary, pyGrad2Surf). Field has been filtered and subsampled to approximately match stereo resolution.

<img width="712" height="602" alt="asit_day024_epss_synthetic_gauges" src="https://github.com/user-attachments/assets/160b9c67-ccbb-4a82-94b5-0e282e517da4" />

Now, after calling ewdm.Arrays():

<img width="2712" height="1298" alt="asit_day024_epss_ewdm_2x4" src="https://github.com/user-attachments/assets/17331fbc-8d0d-4bbf-b9f4-3dd764aaf9fa" />

Early return; quite promising. I'm very eager to use EWDM in this way on the full dataset (and for future observations).