### PR TITLE
Multiaperture Arrays() functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gitignore
 .DS_Store
+docs/figure_scripts/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -164,3 +165,11 @@ cython_debug/
 
 # stereo-video gallery download cache (~1.3 GB, fetched at build time)
 data/stereo-video.nc
+docs/data
+
+# scoped gallery preview build + editor settings
+docs/_gallery_preview/
+.vscode/
+
+# peeled-off follow-up work (array directional estimators), re-applied after multiaperture merges
+.followup/

--- a/docs/gallery/multiaperture_helper.py
+++ b/docs/gallery/multiaperture_helper.py
@@ -1,0 +1,157 @@
+"""Helper functions for the multi-aperture gallery example
+(:ref:`sphx_glr_auto_gallery_plot_multiaperture.py`).
+
+Gathers the pieces that would otherwise clutter the example: a power-normalised
+circular Tukey window and the per-method spectral estimators (a sparse pentagon
+via `ewdm.Arrays`, the direct 3-D FFT spectra and a spreading normaliser) used to
+build the comparison figures.
+"""
+import numpy as np
+import xarray as xr
+from scipy.signal.windows import tukey
+from scipy.ndimage import convolve1d
+import ewdm
+from ewdm.multiaperture import k_dispersion
+from ewdm.parameters import GRAV
+
+
+# -- power-normalised circular Tukey window (radial space + temporal) ----------
+def _radial_tukey(s1, s2, tw):
+    md = min(s1, s2)
+    y, x = np.mgrid[1:s1 + 1, 1:s2 + 1].astype(float)
+    x -= x.mean(); y -= y.mean()
+    r = np.sqrt(x ** 2 + y ** 2) / (md / 2)
+    cp, rs = tw * 2, 1 - tw
+    w = (np.cos(2 * np.pi / cp * (r - rs)) + 1) / 2
+    w[r < (1 - tw)] = 1.0
+    w[r > 1] = 0.0
+    return w
+
+
+def circular_tukey(a, taper_width=0.2, normalization="power", temporal_alpha=0.0):
+    """Apply a radial spatial Tukey (and optional temporal Tukey) to a field
+    ``a`` of shape (ny, nx) or (ny, nx, time), power-normalised by default."""
+    a = np.asarray(a, float)
+    s1, s2, s3 = a.shape if a.ndim == 3 else (a.shape[0], a.shape[1], 1)
+    w2d = _radial_tukey(s1, s2, taper_width)
+    w_t = tukey(s3, temporal_alpha) if (temporal_alpha > 0 and s3 > 1) else np.ones(s3)
+    if normalization == "power":
+        C = 1.0 / np.sqrt(np.mean(w2d ** 2) * np.mean(w_t ** 2))
+    elif normalization == "spectral":
+        C = np.sqrt(s1 * s2) / np.linalg.norm(w2d, 2)
+    else:
+        C = 1.0
+    if a.ndim == 3:
+        return C * w2d[:, :, None] * w_t[None, None, :] * a
+    return C * w2d * a
+
+
+# -- per-method spectral estimators -------------------------------------------
+def pentagon_spectra(field, X, Y, dx, fs, t, indices):
+    """Run `ewdm.Arrays` on a set of pixels (one fixed array). Returns a dict
+    with the frequency and wavenumber spectra, the variance-calibration factor
+    and the anti-alias ceiling k_max = pi / b_max."""
+    px = np.array([X[i, j] for i, j in indices])
+    py = np.array([Y[i, j] for i, j in indices])
+    eta = np.array([field[i, j, :] for i, j in indices]).T
+    bmax = float(np.hypot(px[:, None] - px[None, :], py[:, None] - py[None, :]).max())
+    vpix = float(np.var(eta, axis=0).mean())
+    arr = ewdm.Arrays.from_numpy(time=t, surface_elevation=eta,
+                                 position_x=px, position_y=py, fs=fs)
+    Sf = arr.compute(cross_wavelet=True, kappa=36, coordinate="frequency")
+    Fk = arr.compute(cross_wavelet=True, kappa=36, coordinate="wavenumber")
+    fac = vpix / np.trapezoid(Sf["frequency_spectrum"].values, Sf["frequency"].values)
+    return dict(Sf=Sf, Fk=Fk, fac=fac, kmax=np.pi / bmax)
+
+
+def _log_edges(c):
+    e = np.empty(len(c) + 1)
+    e[1:-1] = np.sqrt(c[:-1] * c[1:])
+    e[0] = c[0] ** 2 / e[1]; e[-1] = c[-1] ** 2 / e[-2]
+    return e
+
+
+def direct_spectra(field, dx, fs, var_eta, freqs, k_grid, pad=2, ddir=4.0):
+    """Windowed 3-D FFT of the whole field. Returns the omnidirectional S(f) and
+    F(k) and the spoke-corrected directional D(f, theta), D(k, theta).
+
+    The omnidirectional S(f) and F(k) come from a sharply windowed, unpadded FFT
+    (spatial Tukey 0.2, temporal 0.25) that keeps the full spatial resolution, so
+    the swell/wind-sea saddle in F(k) is resolved rather than smeared into a flat
+    shelf. The 2-D directional fields, which are noisier and benefit from
+    smoothing, use a wider taper (0.5) and a `pad`-fold zero-pad."""
+    ny, nx, T = field.shape
+    eta0 = field - field.mean(2, keepdims=True)
+    fN = np.fft.rfftfreq(T, 1 / fs)
+    fed = _log_edges(freqs)
+    fin = np.digitize(fN, fed) - 1
+    fok = (fin >= 0) & (fin < len(freqs))
+
+    # omnidirectional S(f), F(k) from a sharp, unpadded FFT (full resolution)
+    A = np.fft.rfftn(circular_tukey(eta0, 0.2, "power", 0.25), axes=(0, 1, 2))
+    P = np.abs(A) ** 2; del A
+    nf = P.shape[2]; P[:, :, 1:nf - 1] *= 2.0; P *= var_eta / P.sum()
+    kmag = np.hypot(*np.meshgrid(2 * np.pi * np.fft.fftfreq(nx, dx),
+                                 2 * np.pi * np.fft.fftfreq(ny, dx))).ravel()
+    Sf_d = np.zeros(len(freqs))
+    np.add.at(Sf_d, fin[fok], P.sum((0, 1))[fok])
+    Sf_d /= np.diff(fed)
+    dkf = 2 * np.pi / (nx * dx)
+    klin = np.arange(dkf, np.pi / dx, dkf)
+    Fk_d = np.histogram(kmag, bins=np.r_[klin - dkf / 2, klin[-1] + dkf / 2],
+                        weights=P.sum(2).ravel())[0] / dkf
+    del P
+
+    # directional spectra from a wider-tapered, zero-padded FFT (smoother 2-D
+    # fields), with a spoke-correction (divide by Cartesian cell count per bin)
+    # and angular + radial smoothing of the hard-binned result
+    A = np.fft.rfftn(circular_tukey(eta0, 0.5, "power", 0.5),
+                     s=(pad * ny, pad * nx, T), axes=(0, 1, 2))
+    P = np.abs(A) ** 2; del A
+    P[:, :, 1:nf - 1] *= 2.0; P *= var_eta / P.sum()
+    kxv = 2 * np.pi * np.fft.fftfreq(pad * nx, dx)
+    kyv = 2 * np.pi * np.fft.fftfreq(pad * ny, dx)
+    KX, KY = np.meshgrid(kxv, kyv)
+    kmag = np.hypot(KX, KY).ravel()
+    ndir = int(360 // ddir); dbins = np.arange(-180, 180, ddir)
+    didx = (np.rint((np.degrees(np.arctan2(KY, KX)) + 180) / ddir).astype(int) % ndir).ravel()
+    ked = _log_edges(k_grid)
+    kri = np.digitize(kmag, ked) - 1
+    kok = (kri >= 0) & (kri < len(k_grid))
+    cnt_th = np.bincount(didx, minlength=ndir).astype(float)
+    cnt_kth = np.zeros((len(k_grid), ndir))
+    np.add.at(cnt_kth, (kri[kok], didx[kok]), 1.0)
+    Fkd = np.zeros((len(k_grid), ndir))
+    np.add.at(Fkd, (kri[kok], didx[kok]), P.sum(2).ravel()[kok])
+    Fft = np.zeros((len(freqs), ndir))
+    for fi in range(1, nf):
+        ft = fin[fi]
+        if 0 <= ft < len(freqs):
+            Fft[ft] += np.bincount(didx, weights=P[:, :, fi].ravel(), minlength=ndir)
+    del P
+    ang = np.hanning(7); ang /= ang.sum()
+    rad = np.hanning(7); rad /= rad.sum()
+    Fft = convolve1d(Fft / np.maximum(cnt_th, 1.0)[None, :], ang, axis=1, mode="wrap")
+    sm = lambda Z: convolve1d(convolve1d(Z, ang, axis=1, mode="wrap"), rad, axis=0, mode="nearest")
+    Fkd = sm(Fkd) / np.maximum(sm(cnt_kth), 1e-9)
+    Dfft = xr.DataArray(Fft, dims=["frequency", "direction"],
+                        coords={"frequency": freqs, "direction": dbins})
+    Dfkd = xr.DataArray(Fkd, dims=["wavenumber", "direction"],
+                        coords={"wavenumber": k_grid, "direction": dbins})
+    return dict(Sf_d=Sf_d, klin=klin, Fk_d=Fk_d, dbins=dbins, Dfft=Dfft, Dfkd=Dfkd)
+
+
+def spreading(da, Xname, lo, hi, blank_lowE=True):
+    """Row-normalise a directional spectrum to the directional distribution
+    D(X, theta) (int D dtheta = 1). Returns (theta, X[slice], D[slice])."""
+    th = da["direction"].values
+    dth = np.radians(np.median(np.diff(th)))
+    v = da.transpose(Xname, "direction").values.astype(float)
+    norm = np.nansum(v, axis=1, keepdims=True) * dth
+    D = np.where(norm > 0, v / norm, np.nan)
+    if blank_lowE:
+        nn = norm[:, 0]
+        D[nn < 1e-3 * np.nanmax(nn)] = np.nan
+    Xv = da[Xname].values
+    s = (Xv >= lo) & (Xv <= hi)
+    return th, Xv[s], D[s]

--- a/docs/gallery/plot_multiaperture.py
+++ b/docs/gallery/plot_multiaperture.py
@@ -1,0 +1,343 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Multi-aperture directional wave spectra
+=======================================
+
+A single fixed array of wave staffs resolves only a narrow band of wavenumbers.
+The phase difference between two staffs separated by a baseline :math:`b` wraps
+once :math:`k\\,b > \\pi`, so an array is trustworthy only below
+:math:`k_{max} = \\pi / b_{max}`. A 2 m pentagon therefore stops at
+:math:`k_{max} \\approx 1.6` rad/m, far short of the wind sea.
+
+`ewdm.MultiApertureArrays` removes this ceiling. Given a dense elevation field
+:math:`\\eta(y, x, t)` it seeds virtual staffs into a *ladder of nested
+apertures*: coarse, widely spaced clusters for the long waves and tight clusters
+for the short waves. Each aperture is trusted only within its own anti-alias band
+and the per-aperture spectra are stitched into one estimate that spans the swell
+through the wind sea, all measured directly from the spatial phase gradients
+without assuming a dispersion relation.
+
+This example runs the method end to end on the `Guimaraes et al (2020)`_ Black
+Sea stereo-video field (19 m field of view, 0.1 m pixels). Supporting functions
+live in ``multiaperture_helper.py`` next to this script.
+
+.. _Guimaraes et al (2020): https://doi.org/10.1038/s41597-020-0492-9
+"""
+
+# sphinx_gallery_thumbnail_number = 2
+
+import os
+import sys
+import subprocess
+
+import numpy as np
+import netCDF4 as nc
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+from matplotlib.colors import LogNorm
+from matplotlib.patches import Circle
+
+import ewdm
+from ewdm import MultiApertureArrays
+from ewdm.multiaperture import auto_apertures, k_dispersion, seed_aperture
+from ewdm.parameters import GRAV
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__))
+                if "__file__" in globals() else os.getcwd())
+from multiaperture_helper import (
+    circular_tukey, pentagon_spectra, direct_spectra, spreading)
+
+# %%
+# Load the field and run the shared computation
+# ---------------------------------------------
+#
+# The stereo-video file is downloaded once into the data folder. We then build
+# the dense field, run the multi-aperture estimator (its default ladder is sized
+# to the field of view), and pre-compute the reference spectra that the figures
+# below compare against: two fixed pentagons (`ewdm.Arrays`) and the direct 3-D
+# FFT spectra.
+
+URL = ("https://data-dataref.ifremer.fr/stereo/BS_2013/"
+       "2013-09-22_13-00-01_10Hz/nc/Surfaces_20130922_130001_short.nc")
+LOCAL = os.path.join("../../data", "stereo-video.nc")
+if not os.path.exists(LOCAL):
+    print("Downloading the stereo-video file (a few minutes the first time).")
+    subprocess.call(f"wget {URL} -O {LOCAL}", shell=True)
+
+o = nc.Dataset(LOCAL)
+X = np.asarray(o["X"][:], float)
+Y = np.asarray(o["Y"][:], float)
+dx = (np.nanmax(X) - np.nanmin(X)) / (X.shape[1] - 1)
+fs, depth, NT = 10.0, 30.0, 2048
+field = np.transpose(np.asarray(o["Z"][:NT], float), (1, 2, 0))   # (ny, nx, time)
+ny, nx, T = field.shape
+t = np.arange(NT) / fs
+var_eta = float((field - field.mean(2, keepdims=True)).var(2).mean())
+ci = cj = (nx - 1) // 2
+
+freqs = np.logspace(np.log10(0.05), np.log10(2.0), 60)
+k_grid = 2.0 ** np.linspace(np.log2(0.03), np.log2(np.pi / dx), 90)
+nu_grid = 2.0 ** np.linspace(np.log2(0.02), np.log2(3.0), 80)
+
+# multi-aperture estimate (data-aware default ladder, per-aperture diagnostics on)
+M = MultiApertureArrays.from_field(
+    field, dx, depth=depth, fs=fs, direction_convention="math").compute(
+    freqs=freqs, k_grid=k_grid, nu_grid=nu_grid, n_staff=16, seed=20,
+    nu_f_lim=None, nu_k_lim=None, lo_frac_broad=1.0, rel_bandwidth=0.10,
+    return_apertures=True)
+
+# fixed pentagons: a broad one and the 2 m ASIS pentagram
+R = int(round(1.0 / dx))
+broad = pentagon_spectra(field, X, Y, dx, fs, t,
+                         [(95, 95), (95, 5), (171, 62), (138, 161), (55, 161), (22, 62)])
+narrow_idx = [(ci, cj)] + [(int(round(ci - R * np.sin(np.radians(90 + 72 * i)))),
+                            int(round(cj + R * np.cos(np.radians(90 + 72 * i)))))
+                           for i in range(5)]
+narrow = pentagon_spectra(field, X, Y, dx, fs, t, narrow_idx)
+
+D = direct_spectra(field, dx, fs, var_eta, freqs, k_grid)          # direct 3-D FFT
+
+# shared style / handy aliases
+MULT, EQC, SATC, DIRC, DISPC, FIXC, ZTOP = "#e31a1c", "#7e3ff2", "C1", "k", "C2", "C0", 12
+SF_M = M["frequency_spectrum"].values
+kw = M["wavenumber"].values
+fpk = freqs[np.nanargmax(SF_M)]
+kpk = kw[np.nanargmax(M["wavenumber_spectrum"].values)]
+topS, topK = np.nanmax(SF_M), np.nanmax(M["wavenumber_spectrum"].values)
+print(f"Hs = {4*np.sqrt(var_eta):.2f} m   fp = {fpk:.2f} Hz   "
+      f"apertures = {len(M['aperture_name'])}")
+
+# %%
+# The problem: a single fixed array
+# ---------------------------------
+#
+# The 2 m pentagon follows the truth up to its baseline limit, then throws up a
+# spurious hump and a sharp energy cliff at the anti-alias ceiling
+# :math:`k_{max} = \pi / b_{max}`, blind to everything shorter.
+
+k_n = narrow["Fk"]["wavenumber"].values
+F_n = narrow["Fk"]["wavenumber_spectrum"].values * narrow["fac"]
+fig, ax = plt.subplots(figsize=(7, 5))
+ax.loglog(D["klin"], D["klin"] ** 3 * D["Fk_d"], "--", color="0.45", lw=1.8,
+          label="true spectrum (3-D FFT)")
+ax.loglog(k_n, k_n ** 3 * F_n, "-", color="C0", lw=2.6,
+          label="single fixed array (2 m)")
+ax.axvline(narrow["kmax"], color="red", ls=":", lw=1.6)
+ax.text(narrow["kmax"] * 0.93, 2e-4, r"$k_{max}=\pi/b_{max}$", rotation=90,
+        va="top", ha="right", color="red", fontsize="small")
+ax.set(xscale="log", yscale="log", xlim=(1e-2, 3e1), ylim=(1e-5, 1e-1),
+       xlabel=r"$k$ [rad m$^{-1}$]", ylabel=r"$k^{3}\,F(k)$ [rad]")
+ax.grid(which="major", ls="-", lw=0.5, alpha=0.6)
+ax.grid(which="minor", ls=":", lw=0.4, alpha=0.5)
+ax.legend(loc="upper left")
+
+# %%
+# The aperture ladder
+# -------------------
+#
+# The default ladder is sized to the field: coarse windows for the swell down to
+# tight five-staff *plus* crosses for the wind sea (no hand-tuning). Four of the
+# larger apertures are drawn over a field snapshot; the panel below plots every
+# aperture's saturation spectrum :math:`k^{3} F(k)` (the four highlighted, the
+# rest dotted) with the stitched composite and the direct 3-D FFT.
+
+apname = [str(a) for a in M["aperture_name"].values]
+apFk, klo, khi = M["aperture_Fk"].values, M["aperture_klo"].values, M["aperture_khi"].values
+kg, Fk_M, extd = M["wavenumber"].values, M["wavenumber_spectrum"].values, dict(auto_apertures(ny, nx, dx))
+bmax_all = np.pi / np.asarray(khi); bl = np.log(bmax_all)
+cands = [i for i in range(len(bl)) if bmax_all[i] >= 2.0] or \
+        sorted(range(len(bl)), key=lambda i: -bmax_all[i])[:4]
+show_idx = []
+for tgt in np.linspace(bl[cands].max(), bl[cands].min(), 4):
+    pool = [i for i in cands if i not in show_idx]
+    show_idx.append(pool[int(np.argmin(np.abs(bl[pool] - tgt)))])
+palette = ['#5e3c99', '#1b9e77', '#e6ab02', '#1f78b4']
+colof = {idx: palette[n] for n, idx in enumerate(show_idx)}
+
+i_snap = 1500 if NT > 1500 else NT // 2
+Zsnap = (field - field.mean(2, keepdims=True))[:, :, i_snap]
+xg = (np.arange(nx) - (nx - 1) / 2.0) * dx
+yg = (np.arange(ny) - (ny - 1) / 2.0) * dx
+vZ = np.percentile(np.abs(Zsnap), 99)
+
+fig = plt.figure(figsize=(8.5, 13), constrained_layout=True)
+gs = fig.add_gridspec(3, 4, height_ratios=[1, 1, 1.7])
+fax = []
+for (r, c), idx in zip([(0, 0), (0, 2), (1, 0), (1, 2)], show_idx):
+    nm, col, ext, w = apname[idx], colof[idx], extd[apname[idx]], float(bmax_all[idx])
+    ax = fig.add_subplot(gs[r, c:c + 2]); fax.append(ax)
+    im = ax.pcolormesh(xg, yg, Zsnap, cmap="coolwarm", vmin=-vZ, vmax=vZ,
+                       shading="auto", rasterized=True); ax.set_aspect("equal")
+    ax.add_patch(Circle((0, 0), w / 2, fill=False, edgecolor=col, lw=2.5))
+    ii, jj, _, _, _ = seed_aperture(ny, nx, dx, ext, 16, 20 + idx)
+    gx, gy = (jj - (nx - 1) / 2.0) * dx, (ii - (ny - 1) / 2.0) * dx
+    ins = np.hypot(gx, gy) <= w / 2.0 + 1e-9
+    ax.scatter(gx[ins], gy[ins], s=14, facecolor="white", edgecolor="black", lw=0.5, zorder=5)
+    ax.text(0.94, 0.94, nm, transform=ax.transAxes, color=col, fontsize="small",
+            fontweight="bold", ha="right", va="top", zorder=6,
+            bbox=dict(boxstyle="round,pad=0.12", fc="white", ec="none", alpha=0.7))
+    ax.set(xlim=(-10, 10), ylim=(-10, 10), xticks=[-10, -5, 0, 5, 10], yticks=[-10, -5, 0, 5, 10])
+    ax.set_ylabel("y [m]") if c == 0 else ax.set_yticklabels([])
+    ax.set_xlabel("x [m]") if r == 1 else ax.set_xticklabels([])
+fig.colorbar(im, ax=fax, location="top", orientation="horizontal",
+             label=r"$\eta$ [m]", shrink=0.6, aspect=40, pad=0.02)
+
+ax = fig.add_subplot(gs[2, :]); k3 = kg ** 3; sel = set(show_idx); _lbl = True
+for idx in range(len(apname)):
+    if idx in sel:
+        continue
+    ax.loglog(kg, k3 * apFk[idx], ":", color="k", lw=0.7, alpha=0.45,
+              label=("other apertures" if _lbl else None)); _lbl = False
+for idx in show_idx:
+    inb = (kg >= klo[idx]) & (kg <= khi[idx])
+    ax.loglog(kg, k3 * apFk[idx], ":", color=colof[idx], lw=1.2, alpha=0.7)
+    ax.loglog(kg[inb], (k3 * apFk[idx])[inb], "-", color=colof[idx], lw=2.0, label=apname[idx])
+fin = np.isfinite(Fk_M)
+ax.loglog(kg[fin], (k3 * Fk_M)[fin], "-", color=MULT, lw=2.6, label="multi-aperture (composite)")
+ax.loglog(D["klin"], D["klin"] ** 3 * D["Fk_d"], "k--", lw=2.4, label="direct")
+ax.set(xlim=(1e-2, 5e1), ylim=(1e-5, 1e-1),
+       xlabel=r"k [rad m$^{-1}$]", ylabel=r"k$^3$ F(k) [rad]")
+ax.grid(which="major", ls="-", lw=0.6); ax.grid(which="minor", ls=":", lw=0.5)
+ax.legend(loc="upper left", ncol=2, fontsize="small")
+
+# %%
+# Omnidirectional spectra
+# -----------------------
+#
+# The composite carries a clean :math:`F(k)` tail far past the reach of any
+# single pentagon, out to :math:`k \sim 10` rad/m, in agreement with the direct
+# FFT and the dispersion image of the frequency spectrum.
+
+def sl(x, xr, yr, p):
+    xx = x[x >= xr]
+    return xx, yr * (xx / xr) ** p
+
+def yat(x, y, xr):
+    return float(np.interp(xr, x, y))
+
+def f_of_k(k):
+    return np.sqrt(GRAV * k * np.tanh(np.clip(k * depth, 1e-9, 50))) / (2 * np.pi)
+
+floorS, floorF = lambda s: 2 * s ** 2 / fs, lambda s: s ** 2 * dx / np.pi
+SIG_REP, SIG_FAR = 0.01, 0.03
+kk_d = k_dispersion(freqs, depth)
+Fk_disp = SF_M * np.abs(np.gradient(freqs, kk_d))
+
+fig, (a, b) = plt.subplots(1, 2, figsize=(10, 4.6), gridspec_kw=dict(wspace=0.24))
+a.loglog(freqs, D["Sf_d"], color=DIRC, lw=1.2, alpha=.75, label="direct 3-D FFT")
+xr_ = 2.2 * fpk
+a.loglog(*sl(freqs, xr_, yat(freqs, SF_M, xr_), -4), ":", color=EQC, lw=2,
+         label=r"equil. ($f^{-4}$, $k^{-5/2}$)")
+a.loglog(*sl(freqs, xr_, 0.45 * yat(freqs, SF_M, xr_), -5), "-.", color=SATC, lw=2,
+         label=r"sat. ($f^{-5}$, $k^{-3}$)")
+a.loglog(freqs, SF_M, lw=2.2, color=MULT, zorder=ZTOP, label="multiaperture (field)")
+a.axvline(f_of_k(broad["kmax"]), color="0.5", ls=":", lw=1)
+a.axhspan(floorS(SIG_REP), floorS(SIG_FAR), color="0.6", alpha=0.18, zorder=0)
+a.axhline(floorS(SIG_REP), color="0.45", lw=1.3); a.axhline(floorS(SIG_FAR), color="0.45", lw=0.7)
+a.set(xlim=(0.05, 5), ylim=(min(topS * 3e-4, floorS(SIG_REP) / 3), topS * 4),
+      xlabel="f [Hz]", ylabel=r"$S(f)$ [m$^2$/Hz]")
+a.text(0.052, np.sqrt(floorS(SIG_REP) * floorS(SIG_FAR)), "WASS quant. floor (~1$\\to$3 cm)",
+       fontsize="small", color="0.3", va="center", ha="left")
+a.legend(loc="upper right", fontsize="small")
+
+b.loglog(broad["Fk"]["wavenumber"], broad["Fk"]["wavenumber_spectrum"] * broad["fac"],
+         "--", color=FIXC, label="broad pentagram")
+b.loglog(narrow["Fk"]["wavenumber"], narrow["Fk"]["wavenumber_spectrum"] * narrow["fac"],
+         ":", color="tab:blue", lw=1.8, label="narrow pentagram (2 m)")
+b.loglog(D["klin"], D["Fk_d"], "o-", color=DIRC, ms=3, lw=1, alpha=.7, label="_nolegend_")
+b.loglog(kk_d, Fk_disp, "--", color=DISPC, lw=1.5, label=r"disp. image of $S(f)$")
+kr = 2 * kpk
+b.loglog(*sl(kw, kr, yat(kw, M["wavenumber_spectrum"].values, kr), -2.5), ":", color=EQC, lw=2, label="_nolegend_")
+b.loglog(*sl(kw, kr, 0.6 * yat(kw, M["wavenumber_spectrum"].values, kr), -3), "-.", color=SATC, lw=2, label="_nolegend_")
+b.loglog(kw, M["wavenumber_spectrum"], lw=2.2, color=MULT, zorder=ZTOP, label="_nolegend_")
+for FX in (broad, narrow):
+    b.axvline(FX["kmax"], color="0.5", ls=":", lw=1.3)
+    b.text(FX["kmax"], 1.02, r"$k_{max}$=%.2f" % FX["kmax"], transform=b.get_xaxis_transform(),
+           color="0.3", va="bottom", ha="center", fontsize="small", clip_on=False)
+b.axhspan(floorF(SIG_REP), floorF(SIG_FAR), color="0.6", alpha=0.18, zorder=0)
+b.axhline(floorF(SIG_REP), color="0.45", lw=1.3); b.axhline(floorF(SIG_FAR), color="0.45", lw=0.7)
+b.set(xlim=(0.03, np.pi / dx), ylim=(min(topK * 3e-4, floorF(SIG_REP) / 3), topK * 4),
+      xlabel="k [rad/m]", ylabel=r"$F(k)$ [m$^3$]")
+b.legend(loc="upper right", fontsize="small")
+
+# %%
+# Directional spectra and spreading
+# ---------------------------------
+#
+# Because each aperture resolves direction as well as wavenumber, the stitched
+# estimate is a full directional spectrum. We compare it against the
+# wavelet-direction (WDM) estimate of the fixed 2 m pentagon and the direct FFT,
+# as the directional spectrum :math:`E(X,\theta)` and, row-normalised, the
+# directional spreading :math:`D(X,\theta)`.
+
+cols = ["fixed pentagram (2 m)", "multiaperture", "direct 3-D FFT"]
+daf = {"fixed pentagram (2 m)": narrow["Sf"]["directional_spectrum"],
+       "multiaperture": M["directional_spectrum_f"], "direct 3-D FFT": D["Dfft"]}
+dak = {"fixed pentagram (2 m)": narrow["Fk"]["directional_spectrum"],
+       "multiaperture": M["directional_spectrum_k"], "direct 3-D FFT": D["Dfkd"]}
+FLIM, KLIM = (0.1, 1.5), (0.05, 4.0)
+L_fov = nx * dx
+f_fov = np.sqrt(GRAV * (2 * np.pi / L_fov)) / (2 * np.pi)
+k_fov = 2 * np.pi / L_fov
+SFd = {c: spreading(daf[c], "frequency", *FLIM) for c in cols}
+th, fv, Dd = SFd["direct 3-D FFT"]; Dd = Dd.copy(); Dd[fv < f_fov] = np.nan
+SFd["direct 3-D FFT"] = (th, fv, Dd)
+SKd = {c: spreading(dak[c], "wavenumber", *KLIM,
+                    blank_lowE=(c not in ("direct 3-D FFT", "multiaperture"))) for c in cols}
+th, kv, Dd = SKd["direct 3-D FFT"]; Dd = Dd.copy(); Dd[kv < k_fov] = np.nan
+SKd["direct 3-D FFT"] = (th, kv, Dd)
+
+
+def two_wide(panels_f, panels_k, cbl_f, cbl_k, cmap, kw_f, kw_k, hline=None):
+    nrow = len(cols)
+    fig, axS = plt.subplots(nrow, 2, figsize=(9.2, 3.1 * nrow), gridspec_kw=dict(wspace=0.34))
+    for i, c in enumerate(cols):
+        thh, xv, Z = panels_f[c]; axS[i, 0].pcolormesh(thh, xv, Z, cmap=cmap, shading="auto", **kw_f)
+        axS[i, 0].set(ylabel=r"$f$ [Hz]", yscale="log", ylim=FLIM, xlim=(-180, 180))
+        thh, xv, Z = panels_k[c]; axS[i, 1].pcolormesh(thh, xv, Z, cmap=cmap, shading="auto", **kw_k)
+        axS[i, 1].set(ylabel=r"$k$ [rad/m]", yscale="log", ylim=KLIM, xlim=(-180, 180))
+        # field-of-view lower limit of the direct 3-D FFT (one wavelength across
+        # the field of view)
+        if hline is not None:
+            axS[i, 0].axhline(f_fov, ls="--", color=hline, lw=1.3, zorder=4)
+            axS[i, 1].axhline(k_fov, ls="--", color=hline, lw=1.3, zorder=4)
+        for ax in (axS[i, 0], axS[i, 1]):
+            ax.set_xticks(np.arange(-180, 181, 45))
+        axS[i, 1].text(1.14, 0.5, c, transform=axS[i, 1].transAxes, rotation=-90,
+                       va="center", ha="left", fontsize="medium")
+        if i < nrow - 1:
+            axS[i, 0].set_xticklabels([]); axS[i, 1].set_xticklabels([])
+        else:
+            axS[i, 0].set_xlabel(r"direction $\theta$ [deg]")
+            axS[i, 1].set_xlabel(r"direction $\theta$ [deg]")
+    for col, lab in ((0, cbl_f), (1, cbl_k)):
+        cb = fig.colorbar(axS[0, col].collections[0], ax=axS[:, col].tolist(),
+                          location="top", orientation="horizontal", shrink=0.9, aspect=30, pad=0.03)
+        cb.set_label(lab)
+    return fig
+
+# directional spectrum E(X,theta) = D(X,theta) * S_omni(X) on the multiaperture backbone
+mf_x, mf_y = M["frequency"].values, M["frequency_spectrum"].values
+mk_x, mk_y = kw, M["wavenumber_spectrum"].values
+EF = {c: (SFd[c][0], SFd[c][1], SFd[c][2] * np.interp(SFd[c][1], mf_x, mf_y)[:, None]) for c in cols}
+EK = {c: (SKd[c][0], SKd[c][1], SKd[c][2] * np.interp(SKd[c][1], mk_x, mk_y)[:, None]) for c in cols}
+vmaxEf = np.nanpercentile(np.concatenate([EF[c][2].ravel() for c in cols]), 99.5)
+vmaxEk = np.nanpercentile(np.concatenate([EK[c][2].ravel() for c in cols]), 99.5)
+_vir = plt.cm.viridis(np.linspace(0, 1, 256)); _vir[:, 3] = np.clip(np.linspace(0, 1, 256) / 0.06, 0, 1)
+epss = mcolors.ListedColormap(_vir); epss.set_bad("0.9")
+two_wide(EF, EK, r"$E(f,\theta)$  [m$^2$ Hz$^{-1}$ rad$^{-1}$]",
+         r"$\Psi(k,\theta)$  [m$^3$ rad$^{-1}$]", epss,
+         dict(norm=LogNorm(vmin=vmaxEf * 10 ** -2.5, vmax=vmaxEf)),
+         dict(norm=LogNorm(vmin=vmaxEk * 10 ** -2.5, vmax=vmaxEk)), hline="red")
+
+# %%
+# Directional spreading (row-normalised to unit directional integral):
+
+vmaxDf = np.nanpercentile(np.concatenate([SFd[c][2].ravel() for c in cols]), 99)
+vmaxDk = np.nanpercentile(np.concatenate([SKd[c][2].ravel() for c in cols]), 99)
+mag = plt.cm.magma.copy(); mag.set_bad("0.92")
+two_wide(SFd, SKd, r"$D(f,\theta)$  [rad$^{-1}$]", r"$D(k,\theta)$  [rad$^{-1}$]", mag,
+         dict(vmin=0, vmax=vmaxDf), dict(vmin=0, vmax=vmaxDk), hline="white")

--- a/docs/gallery/plot_multiaperture_stereo.py
+++ b/docs/gallery/plot_multiaperture_stereo.py
@@ -1,0 +1,186 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Multi-aperture spectra from stereo-video
+========================================
+The companion stereo-imaging example picks a handful of pixels from the field of
+view and feeds their elevation time series to `ewdm.Arrays`, just as one would
+with a real wave-staff array. Here we instead hand the *whole* dense elevation
+field eta(y, x, t) to `ewdm.MultiApertureArrays`.
+
+Rather than a single fixed array, the estimator seeds virtual staffs into a
+ladder of nested apertures: coarse, widely spaced clusters for the long waves and
+tight clusters for the short waves. Each aperture is only trusted within its own
+anti-alias band and the per-aperture spectra are stitched together. From a single
+field this yields not only the frequency-direction spectrum but also the
+wavenumber spectrum F(k) and the inverse-phase-speed spectrum Q(nu), measured
+directly from the spatial phase gradients without assuming a dispersion relation.
+
+This example uses the same `Guimaraes et al (2020)`_ Black Sea data as the
+stereo-imaging example, and compares the result against `ewdm.Arrays` on a
+sparse pentagon of pixels.
+
+.. _Guimaraes et al (2020): https://doi.org/10.1038/s41597-020-0492-9
+"""
+
+import os
+import subprocess
+
+import numpy as np
+import netCDF4 as nc
+import matplotlib.pyplot as plt
+
+import ewdm
+from ewdm.plots import plot_directional_spectrum
+
+# define paths and filenames (shared with the stereo-imaging example)
+URL = "https://data-dataref.ifremer.fr/stereo/BS_2013/"
+VIDEO_URL = URL + "2013-09-22_13-00-01_10Hz/nc/Surfaces_20130922_130001_short.nc"
+CACHE_DIR = "../../data/"
+LOCAL_VIDEO_FILE = os.path.join(CACHE_DIR, "stereo-video.nc")
+
+# Black Sea acquisition parameters
+SAMPLING_RATE = 10.0        # Hz
+DEPTH = 30.0                # m (deep water for these short wind waves)
+NFRAMES = 4096              # subset of frames
+
+
+# %%
+# Downloading the stereo-video dataset
+# ------------------------------------
+#
+# We download the netCDF4 file with the stereo-imaging surfaces and place it in
+# the data folder. This might take a few minutes the first time.
+
+if not os.path.exists(LOCAL_VIDEO_FILE):
+    print("Downloading the stereo-video file. It might take a few minutes.")
+    subprocess.call(f"wget {VIDEO_URL} -O {LOCAL_VIDEO_FILE}", shell=True)
+else:
+    print("File already exists. Skipping download.")
+
+nc_obj = nc.Dataset(LOCAL_VIDEO_FILE)
+
+
+# %%
+# Building the elevation field
+# ----------------------------
+#
+# The dataset stores the gridded sea surface elevation `Z(time, y, x)` together
+# with the pixel coordinates `X` and `Y` in metres. We read a subset of the
+# frames and arrange the field as (ny, nx, time), the layout expected by
+# `MultiApertureArrays.from_field`.
+
+X = np.asarray(nc_obj["X"][:], float)
+Y = np.asarray(nc_obj["Y"][:], float)
+dx = (np.nanmax(X) - np.nanmin(X)) / (X.shape[1] - 1)
+
+Z = np.asarray(nc_obj["Z"][:NFRAMES, :, :], float)   # (time, ny, nx)
+field = np.transpose(Z, (1, 2, 0))                   # (ny, nx, time)
+del Z
+
+print(f"field (ny, nx, time) = {field.shape}")
+print(f"dx = {dx:.3f} m   field of view = {field.shape[1] * dx:.1f} m")
+
+
+# %%
+# Computing the multi-aperture spectra
+# ------------------------------------
+#
+# The field of view is only a few wavelengths wide, so this is the small-aperture
+# regime the default ladder is tuned for. We keep the anti-alias gate off (the
+# default) since here the dominant wave is near the field-of-view scale.
+
+spec = ewdm.MultiApertureArrays.from_field(field, dx, depth=DEPTH,
+                                           fs=SAMPLING_RATE)
+output = spec.compute(n_staff=16, seed=20, return_apertures=True)
+print(output)
+
+Hs = 4 * np.sqrt(float(output["var_eta"]))
+f = output["frequency"].values
+fp = f[np.nanargmax(output["frequency_spectrum"].values)]
+print(f"Hs = {Hs:.2f} m   Tp = {1 / fp:.1f} s")
+
+
+# %%
+# Comparing against a sparse array
+# --------------------------------
+#
+# As a reference we run `ewdm.Arrays` on a pentagon of pixels, exactly as in the
+# stereo-imaging example. The two frequency spectra peak at the same period; the
+# dense field additionally gives a smoother spectrum and a fuller tail.
+
+indices = [(95, 95), (95, 5), (171, 62), (138, 161), (55, 161), (22, 62)]
+px = np.array([X[i, j] for i, j in indices])
+py = np.array([Y[i, j] for i, j in indices])
+eta = np.array([field[i, j, :] for i, j in indices]).T
+time = np.arange(NFRAMES) / SAMPLING_RATE
+
+arr = ewdm.Arrays.from_numpy(
+    time=time, surface_elevation=eta, position_x=px, position_y=py,
+    fs=SAMPLING_RATE
+)
+pentagon = arr.compute(cross_wavelet=True, solver="least-squares", kappa=36)
+
+fig, ax = plt.subplots()
+ax.loglog(output["frequency"], output["frequency_spectrum"],
+          label="multiaperture (dense field)")
+ax.loglog(pentagon["frequency"], pentagon["frequency_spectrum"], "--",
+          label="Arrays (pentagon)")
+ax.set(xlabel="f [Hz]", ylabel="$S(f)$ [m$^2$/Hz]", title="Frequency spectrum")
+ax.legend()
+
+
+# %%
+# The wavenumber and inverse-phase-speed spectra
+# ----------------------------------------------
+#
+# The single fixed array can also be
+# asked for a wavenumber spectrum (`coordinate="wavenumber"`), but it only
+# resolves the narrow band around its own baseline and falls off a cliff at
+# higher k. The multi-aperture estimator stitches the nested apertures together
+# and carries a clean F(k) tail across the short waves the fixed array is blind
+# to. The inverse-phase-speed spectrum Q(nu) of Björkqvist et al. (2019) tells
+# the same story.
+
+pentagon_k = arr.compute(cross_wavelet=True, solver="least-squares", kappa=36,
+                         coordinate="wavenumber")
+pentagon_nu = arr.compute(cross_wavelet=True, solver="least-squares", kappa=36,
+                          coordinate="nu")
+
+fig, (axk, axn) = plt.subplots(1, 2, figsize=(10, 4))
+axk.loglog(output["wavenumber"], output["wavenumber_spectrum"],
+           label="multiaperture (dense field)")
+axk.loglog(pentagon_k["wavenumber"], pentagon_k["wavenumber_spectrum"], "--",
+           label="Arrays (pentagon)")
+axk.set(xlabel="k [rad/m]", ylabel="$F(k)$ [m$^3$]",
+        title="Wavenumber spectrum")
+top = np.nanmax(output["wavenumber_spectrum"].values)
+axk.set_ylim(top * 1e-4, top * 3)
+axk.legend()
+
+axn.loglog(output["nu"], output["nu_spectrum"],
+           label="multiaperture (dense field)")
+axn.loglog(pentagon_nu["nu"], pentagon_nu["nu_spectrum"], "--",
+           label="Arrays (pentagon)")
+axn.set(xlabel=r"$\nu = k / \omega$ [s/m]", ylabel="$Q(\\nu)$ [m$^3$/s]",
+        title="Inverse-phase-speed spectrum")
+top = np.nanmax(output["nu_spectrum"].values)
+axn.set_ylim(top * 1e-4, top * 3)
+axn.legend()
+fig.tight_layout()
+
+
+# %%
+# Finally, the polar wavenumber-direction spectrum. The dominant wave system
+# appears as a single lobe at its wavenumber and direction (degrees clockwise
+# from North).
+
+fig, ax = plt.subplots(figsize=(6, 5))
+plot_directional_spectrum(
+    output["directional_spectrum_k"], frqs="wavenumber", ax=ax, levels=None,
+    colorbar=True,
+    axes_kw={"rmin": 0.2, "rmax": 2.0, "rstep": 0.4},
+    cbar_kw={"label": "$\\Psi(k,\\theta)$"}
+)

--- a/ewdm/__init__.py
+++ b/ewdm/__init__.py
@@ -16,3 +16,4 @@ from . import plots
 from . import sources
 from . import wavelets
 from .main import Triplets, Arrays
+from .multiaperture import MultiApertureArrays

--- a/ewdm/multiaperture.py
+++ b/ewdm/multiaperture.py
@@ -1,0 +1,1205 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Composite multi-aperture directional wave spectra.
+
+Each wavenumber octave is resolved with a matched aperture: coarse, widely
+spaced staffs for the long waves (low wavenumber) and tight clusters for the
+short waves (high wavenumber). Every aperture is only trusted within its own
+anti-alias band, k < pi / baseline_max, and the per-aperture spectra are then
+stitched together. Two kinds of input are supported:
+
+* a dense elevation field eta(y, x, t) together with the grid spacing dx, from
+  which virtual staffs are seeded into nested apertures. This is built with the
+  `from_field` constructor.
+
+* a sparse sensor array following the same convention as the `Arrays` class,
+  from which nested sub-apertures are grouped by baseline. This is built with
+  the `from_arrays` (or `from_numpy`) constructor.
+
+The estimator only deals with the array-measured (wavelet directional method)
+machinery. The camera slope-to-elevation reconstruction and any external sign
+anchor (for example a 3D FFT estimate) are left to the caller and passed in as
+hooks, namely the `solve_eta` and `sign_anchor` arguments of `compute`.
+
+Wave direction is reported in degrees clockwise from North (the oceanographic
+convention) by default. Set `direction_convention="math"` to obtain instead the
+eastward-northward math angle used elsewhere in ewdm.
+"""
+
+import logging
+
+import numpy as np
+import xarray as xr
+
+from .wavelets import cwt, Morlet
+from .density import (estimate_directional_distribution,
+                      estimate_radial_distribution)
+from .helpers import get_sampling_frequency
+from .parameters import VARIABLE_NAMES, GRAV
+
+logger = logging.getLogger(__name__)
+
+# numpy 2.0 renamed `np.trapz` to `np.trapezoid`; use the new name when
+# available, fall back on older numpy. mirrors the shim in `density.py`.
+_trapezoid = getattr(np, "trapezoid", getattr(np, "trapz", None))
+
+RADTODEG = 180. / np.pi
+
+
+# dispersion relation and circular statistics {{{
+def _nu_of_k(k, depth):
+    """Inverse phase speed nu = k / omega along the linear dispersion relation."""
+    return np.sqrt(k / (GRAV * np.tanh(np.clip(k * depth, 1e-9, 50.0))))
+
+
+def k_dispersion(f, depth):
+    """Linear gravity-wave wavenumber k(f) in rad/m at finite depth.
+
+    The dispersion relation is solved iteratively because the wavenumber appears
+    on both sides through the hyperbolic tangent.
+    """
+    w = 2 * np.pi * np.asarray(f, float)
+    k = w**2 / GRAV
+    for _ in range(100):
+        k_new = w**2 / (GRAV * np.tanh(np.clip(k * depth, 1e-9, 50.0)))
+        converged = np.allclose(k_new, k, rtol=1e-12, atol=0.0)
+        k = k_new
+        if converged:
+            break
+    return k
+
+
+def circ_stats(F, theta_deg, axis=-1):
+    """Energy-weighted circular mean direction and spread in degrees.
+
+    The mean direction and angular spread are computed from the first
+    trigonometric moment of the directional spectrum F over the direction axis.
+    """
+    a = np.radians(theta_deg)
+    C = np.sum(F * np.cos(a), axis=axis)
+    S = np.sum(F * np.sin(a), axis=axis)
+    tot = np.sum(F, axis=axis)
+    tot = np.where(tot == 0, np.nan, tot)
+    R = np.hypot(C, S) / tot
+    mean = np.degrees(np.arctan2(S, C)) % 360.0
+    spread = np.degrees(np.sqrt(np.clip(2.0 * (1.0 - R), 0, None)))
+    return mean, spread
+
+
+def _math_angle_to_cw_from_N(theta_en_rad, flip=False):
+    """Convert an eastward-northward math angle (radians, counter-clockwise from
+    East) into a compass direction in degrees (clockwise from North), wrapped to
+    the [-180, 180) interval."""
+    deg = (90.0 - np.degrees(theta_en_rad)) % 360.0
+    if flip:
+        deg = (deg + 180.0) % 360.0
+    return ((deg + 180.0) % 360.0) - 180.0
+
+
+def _cw_from_N_to_math_angle(deg_cwN):
+    """Inverse of `_math_angle_to_cw_from_N`: convert a compass direction in
+    degrees (clockwise from North) into the eastward-northward math angle in
+    degrees, wrapped to the [-180, 180) interval."""
+    a = (90.0 - np.asarray(deg_cwN, float)) % 360.0
+    return ((a + 180.0) % 360.0) - 180.0
+
+
+def _wrap180(x):
+    """Wrap an angle in degrees to the [-180, 180) interval."""
+    return ((x + 180.0) % 360.0) - 180.0
+# }}}
+
+
+# array geometry, aperture seeding and stitching {{{
+def erode_valid(valid):
+    """Erode a boolean footprint by one pixel.
+
+    Only pixels whose four neighbours are all inside the footprint are kept, so
+    that central-difference gradients stay within it.
+    """
+    ev = valid.copy()
+    ev[1:-1, 1:-1] &= (valid[:-2, 1:-1] & valid[2:, 1:-1]
+                       & valid[1:-1, :-2] & valid[1:-1, 2:])
+    ev[[0, -1], :] = False
+    ev[:, [0, -1]] = False
+    return ev
+
+
+def seed_aperture(ny, nx, dx, extent_px, n_staff, seed, valid=None):
+    """Draw random virtual staffs inside a centred window.
+
+    Args:
+        ny, nx (int): Number of grid rows and columns.
+        dx (float): Grid spacing in metres.
+        extent_px (int or tuple): Window side in pixels. A scalar gives a square
+            window, a (rows, cols) tuple a rectangular one.
+        n_staff (int): Number of virtual staffs to draw.
+        seed (int): Seed for the random number generator.
+        valid (np.ndarray, optional): Boolean footprint. When given, staffs are
+            drawn only from the True pixels, the window is recentred on the valid
+            centroid and the staffs are sampled without replacement (with
+            replacement only if fewer than `n_staff` pixels are available).
+
+    Returns:
+        tuple: The row and column indices of the staffs, their easting and
+        northing positions in metres and the longest baseline. The column axis
+        is West-positive, so East = (cxp - j) dx and North = (cyp - i) dx.
+    """
+    rng = np.random.default_rng(seed)
+    cxp, cyp = (nx - 1) / 2, (ny - 1) / 2
+    # deterministic plus (cross) aperture: centre + four arms at +/- arm_px, a
+    # tight, well-conditioned high-wavenumber rung. arm_px may be fractional
+    # (the field is bilinearly sampled when the staff series are extracted).
+    if isinstance(extent_px, (tuple, list)) and len(extent_px) == 2 and extent_px[0] == "plus":
+        a = float(extent_px[1])
+        ii = np.array([cyp, cyp, cyp, cyp + a, cyp - a])
+        jj = np.array([cxp, cxp + a, cxp - a, cxp, cxp])
+        px = (cxp - jj) * dx; py = (cyp - ii) * dx
+        b = np.hypot(px[:, None] - px[None, :], py[:, None] - py[None, :])
+        return ii, jj, px, py, float(b.max())
+    ey, ex = extent_px if isinstance(extent_px, (tuple, list)) else (extent_px, extent_px)
+    ey = int(min(ey, ny - 1))
+    ex = int(min(ex, nx - 1))
+
+    # draw staffs either from the whole centred window or, when a footprint is
+    # given, only from the valid pixels around the footprint centroid
+    if valid is None:
+        i0 = (ny - ey) // 2
+        j0 = (nx - ex) // 2
+        ii = rng.integers(i0, i0 + ey + 1, n_staff)
+        jj = rng.integers(j0, j0 + ex + 1, n_staff)
+    else:
+        vi, vj = np.where(valid)
+        ci, cj = int(round(vi.mean())), int(round(vj.mean()))
+        i0, j0 = max(ci - ey // 2, 0), max(cj - ex // 2, 0)
+        wi, wj = np.where(valid[i0:i0 + ey + 1, j0:j0 + ex + 1])
+        # if the window missed the footprint, fall back to all valid pixels
+        if wi.size == 0:
+            wi, wj, i0, j0 = vi, vj, 0, 0
+        pick = rng.choice(wi.size, size=n_staff, replace=wi.size < n_staff)
+        ii, jj = wi[pick] + i0, wj[pick] + j0
+
+    # convert pixel indices to physical positions and find the longest baseline
+    px = (cxp - jj) * dx
+    py = (cyp - ii) * dx
+    b = np.hypot(px[:, None] - px[None, :], py[:, None] - py[None, :])
+    return ii, jj, px, py, float(b.max())
+
+
+def _bilinear_stack(arr, ii, jj):
+    """Sample arr (ny, nx, T) at (possibly fractional) staff rows ii and columns
+    jj by bilinear interpolation. Reduces to plain indexing for integer ii, jj."""
+    ny, nx = arr.shape[:2]
+    ii = np.asarray(ii, dtype=float); jj = np.asarray(jj, dtype=float)
+    i0 = np.floor(ii).astype(int); j0 = np.floor(jj).astype(int)
+    fi = ii - i0; fj = jj - j0
+    i0 = np.clip(i0, 0, ny - 1); j0 = np.clip(j0, 0, nx - 1)
+    i1 = np.clip(i0 + 1, 0, ny - 1); j1 = np.clip(j0 + 1, 0, nx - 1)
+    return np.stack([
+        (1 - fi[s]) * (1 - fj[s]) * arr[i0[s], j0[s]]
+        + (1 - fi[s]) * fj[s] * arr[i0[s], j1[s]]
+        + fi[s] * (1 - fj[s]) * arr[i1[s], j0[s]]
+        + fi[s] * fj[s] * arr[i1[s], j1[s]]
+        for s in range(len(i0))])
+
+
+def aperture_band(b_max, lo_frac=0.30, hi_frac=1.0):
+    """Trusted wavenumber band of an aperture.
+
+    The band runs from the smallest resolvable phase over the longest baseline,
+    lo_frac / b_max, up to the anti-alias ceiling, hi_frac * pi / b_max.
+    """
+    return lo_frac / b_max, hi_frac * np.pi / b_max
+
+
+def _log_edge_taper(grid, lo, hi, width):
+    """Cosine edge weight on a logarithmic grid.
+
+    The weight is one inside the band [lo, hi] and tapers smoothly to zero over
+    `width` octaves at each edge, and is zero outside. This down-weights each
+    aperture's anti-alias tail where neighbouring bands overlap and cancels in
+    single-aperture regions.
+    """
+    lg = np.log2(grid)
+    llo, lhi = np.log2(lo), np.log2(hi)
+    ramp = np.clip(np.minimum((lg - llo) / width, (lhi - lg) / width), 0.0, 1.0)
+    t = 0.5 * (1.0 - np.cos(np.pi * ramp))
+    return np.where((lg > llo) & (lg < lhi), t, 0.0)
+
+
+def default_apertures():
+    """Default coarse-to-tight ladder of apertures.
+
+    Returns a list of (name, extent_px) tuples spaced by roughly a factor 1.3 so
+    that every wavenumber octave is covered by at least two apertures, leaving no
+    single-aperture notch at the stitches.
+    """
+    return [('A0', 28), ('A1', 22), ('A2', 17), ('A3', 13),
+            ('A4', 10), ('A5', 8), ('A6', 6), ('A7', 4)]
+
+
+def auto_apertures(ny, nx, dx, fov_frac=0.55, b_min_px=3.0, ratio=1.4,
+                   min_window_px=12):
+    """Data-aware coarse-to-tight aperture ladder sized to the field.
+
+    Builds a half-octave ladder of baselines from a fraction of the field of
+    view down to a few pixels, so the stitched spectrum spans the swell through
+    the wind sea without the caller hand-tuning a pixel ladder. Coarse rungs are
+    random windows (well sampled); the tight high-wavenumber rungs are
+    deterministic plus (cross) apertures, which stay well conditioned where a
+    random window would have too few pixels.
+
+    Args:
+        ny, nx (int): Field shape in pixels.
+        dx (float): Grid spacing in metres.
+        fov_frac (float): Coarsest baseline as a fraction of the (smaller) field
+            extent; sets the longest resolved wave (default 0.55).
+        b_min_px (float): Tightest baseline in pixels; sets the anti-alias
+            ceiling k_max = pi / (b_min_px * dx) (default 3).
+        ratio (float): Baseline ratio between successive rungs (default 1.4, a
+            half octave, so neighbouring trusted bands overlap).
+        min_window_px (int): Rungs with an extent below this many pixels are
+            emitted as plus crosses instead of random windows (default 12).
+
+    Returns:
+        list: ``(name, extent)`` tuples, where ``extent`` is an integer window
+        side in pixels or ``("plus", arm_px)`` for a cross aperture.
+    """
+    L = min(ny, nx) * dx
+    b0 = fov_frac * L
+    b_min = b_min_px * dx
+    n = max(2, int(np.ceil(np.log(b0 / b_min) / np.log(ratio))) + 1)
+    aps = []
+    for i, b in enumerate(np.geomspace(b0, b_min, n)):
+        ext_px = b / dx
+        if ext_px >= min_window_px:
+            aps.append((f"A{i}", int(round(ext_px))))
+        else:
+            aps.append((f"A{i}", ("plus", round(b / 2.0 / dx, 3))))
+    return aps
+
+
+def default_grids(dx, fmin=0.06, fmax=3.5, nfreq=52,
+                  kmin=0.08, numin=0.01, numax=2.0, nrad=64):
+    """Default log-spaced frequency, wavenumber and inverse phase speed grids.
+
+    The wavenumber grid runs up to the pixel Nyquist pi / dx.
+    """
+    freqs = np.logspace(np.log10(fmin), np.log10(fmax), nfreq)
+    kmax = np.pi / dx
+    k_grid = 2.0**np.linspace(np.log2(kmin), np.log2(kmax), nrad)
+    nu_grid = 2.0**np.linspace(np.log2(numin), np.log2(numax), nrad)
+    return freqs, k_grid, nu_grid
+# }}}
+
+
+# wavelet wavevectors and sign resolution {{{
+def cwt_stack(staff_series, freqs, fs, omega0=6.0):
+    """Continuous wavelet transform of each staff time series.
+
+    Args:
+        staff_series (np.ndarray): Stack of staff time series.
+        freqs (np.ndarray): Frequency array.
+        fs (float): Sampling frequency.
+        omega0 (float): Morlet central frequency. Larger values give a finer
+            frequency resolution (df / f is of order 1 / omega0) at the expense
+            of a coarser time resolution and therefore noisier statistics.
+
+    Returns:
+        np.ndarray: Complex coefficients with shape (n_staff, n_freq, n_time).
+    """
+    mother = Morlet(omega0)
+    return np.stack([cwt(s.astype(float), freqs=freqs, fs=fs, mother=mother).values
+                     for s in staff_series])
+
+
+def solve_wavevectors(W, px, py):
+    """Least-squares wavevector from the cross-staff phase differences.
+
+    For each frequency and time, the wavevector is solved from the phase
+    differences of every staff pair. Returns a root-mean-square residual rather
+    than numpy's least-squares residual; kept separate from
+    `Arrays.compute_wavenumbers` so this estimator stays self-contained.
+
+    Args:
+        W (np.ndarray): Wavelet coefficients with shape (n_staff, n_freq, n_time).
+        px, py (np.ndarray): Staff positions in metres.
+
+    Returns:
+        tuple: The two wavevector components, the root-mean-square residual and a
+        normalised misfit, each with shape (n_freq, n_time). The misfit is the
+        residual divided by the phase-difference magnitude; it is near zero for a
+        cleanly resolved plane wave and approaches one when the phase differences
+        are inconsistent across pairs (a short wave aliased by a coarse aperture,
+        or a noise-dominated sample). It drives the optional reliability gate in
+        :meth:`MultiApertureArrays.compute`.
+
+    Notes:
+        The misfit catches the dominant spurious shift of energy towards zero
+        wavenumber from short waves aliased by an over-large aperture: those
+        wrap the phase inconsistently across pairs of different baseline, giving
+        a large residual. It makes no dispersion assumption. It does not flag the
+        weaker sub-footprint bias, where a wave longer than the aperture gives
+        small consistent phase differences and a low misfit; that mode is
+        addressed by the de-pistoning hook (`solve_eta`).
+    """
+    nstaff, nf, T = W.shape
+    pairs = [(m, n) for m in range(nstaff) for n in range(m + 1, nstaff)]
+    A = np.array([[px[n] - px[m], py[n] - py[m]] for m, n in pairs])
+
+    # initialise the wavevector components, residual and normalised misfit
+    kx = np.empty((nf, T))
+    ky = np.empty((nf, T))
+    resid = np.empty((nf, T))
+    misfit = np.empty((nf, T))
+
+    # loop for each frequency and solve the least-squares system over all pairs
+    for fi in range(nf):
+        dphi = np.empty((len(pairs), T))
+        for q, (m, n) in enumerate(pairs):
+            dphi[q] = np.angle(W[n, fi] * np.conj(W[m, fi]))
+        sol, *_ = np.linalg.lstsq(A, dphi, rcond=None)
+        kx[fi], ky[fi] = sol[0], sol[1]
+        resid[fi] = np.sqrt(np.mean((A @ sol - dphi)**2, axis=0))
+        misfit[fi] = resid[fi] / (np.sqrt(np.mean(dphi**2, axis=0)) + 1e-9)
+    return kx, ky, resid, misfit
+
+
+def lh_direction(We, Wsx, Wsy, flip=False):
+    """Longuet-Higgins first-moment mean direction.
+
+    The unambiguous (0 to 360 degrees) mean direction is computed from the
+    co-located heave and slope wavelet coefficients, where the slopes are the
+    gradient of the elevation. This resolves the 180-degree sign ambiguity of the
+    array solution. The result is returned in degrees clockwise from North.
+    """
+    cross_x = np.mean(We * np.conj(Wsx), axis=(0, 2))
+    cross_y = np.mean(We * np.conj(Wsy), axis=(0, 2))
+    Cee = np.mean(np.abs(We)**2, axis=(0, 2))
+    Cxx = np.mean(np.abs(Wsx)**2, axis=(0, 2))
+    Cyy = np.mean(np.abs(Wsy)**2, axis=(0, 2))
+    den = np.sqrt(np.clip(Cee * (Cxx + Cyy), 1e-30, None))
+    return _math_angle_to_cw_from_N(np.arctan2(np.imag(cross_y) / den,
+                                               np.imag(cross_x) / den), flip=flip)
+# }}}
+
+
+# multi-aperture estimator {{{
+class MultiApertureArrays:
+    """Perform multi-aperture EWDM for dense fields or sparse spatial arrays.
+
+    The class is constructed with one of the factory methods, `from_field` for a
+    dense elevation grid or `from_arrays` (`from_numpy`) for a sparse sensor
+    array, and the spectra are produced by the `compute` method. See the module
+    docstring for the input conventions.
+
+    Arguments:
+        field (np.ndarray, optional): Dense elevation field with shape
+            (ny, nx, time). Rows are North and columns are East, with a
+            West-positive column axis as used by `seed_aperture`.
+        dx (float, optional): Grid spacing in metres. Required for a dense field.
+        valid (np.ndarray, optional): Boolean footprint of the dense field.
+        dataset (xr.Dataset, optional): Sparse sensor array following the
+            `Arrays` convention.
+        depth (float): Mean water depth in metres.
+        fs (float, optional): Sampling frequency in Hz. For a sparse array it is
+            inferred from the time coordinate when not given.
+        direction_convention (str): Either `cw_from_north` (default) or `math`.
+    """
+
+    def __init__(self, *, field=None, dx=None, valid=None,
+                 dataset=None, depth=None, fs=None,
+                 direction_convention='cw_from_north'):
+
+        # exactly one of a dense field or a sparse dataset must be supplied
+        if (field is None) == (dataset is None):
+            raise ValueError(
+                "Provide exactly one of a dense `field` or a sparse `dataset`. "
+                "Use the `from_field` or `from_arrays` factory methods."
+            )
+        if depth is None:
+            raise ValueError("`depth`, the mean water depth in metres, is required.")
+        if direction_convention not in ("cw_from_north", "math"):
+            raise ValueError(
+                "`direction_convention` must be `cw_from_north` or `math`."
+            )
+
+        self.field = field
+        self.dx = dx
+        self.valid = valid
+        self.dataset = dataset
+        self.depth = float(depth)
+        self.fs = fs
+        self.direction_convention = direction_convention
+        self.mode = "field" if field is not None else "sparse"
+
+        # validate and derive the geometry depending on the input mode
+        if self.mode == "field":
+            if dx is None:
+                raise ValueError(
+                    "`dx`, the grid spacing in metres, is required for a dense field."
+                )
+            self.field = np.asarray(field, dtype=float)
+            if self.field.ndim != 3:
+                raise ValueError("`field` must have shape (ny, nx, time).")
+            ny, nx, _ = self.field.shape
+            # frame-fundamental wavenumber, used later by the `auto` nu gate
+            self._kfov = 2 * np.pi / (nx * self.dx)
+        else:
+            self._prepare_sparse(dataset)
+
+
+    @classmethod
+    def from_field(cls, eta, dx, depth, fs, *, valid=None,
+                   direction_convention='cw_from_north'):
+        """Create an instance from a dense elevation grid.
+
+        Arguments:
+            eta: Elevation field with shape (ny, nx, time). Rows are North and
+                columns are East, with a West-positive column axis.
+            dx: Grid spacing in metres.
+            depth: Mean water depth in metres.
+            fs: Sampling frequency in Hz.
+            valid: Optional (ny, nx) boolean footprint. The elevation may be NaN
+                outside it; the variance is taken over the footprint and the
+                staffs are drawn from its one-pixel-eroded pixels.
+            direction_convention: Either `cw_from_north` (default) or `math`.
+        """
+        return cls(field=eta, dx=dx, valid=valid, depth=depth, fs=fs,
+                   direction_convention=direction_convention)
+
+
+    @classmethod
+    def from_arrays(cls, dataset, depth, fs=None, *,
+                    direction_convention='cw_from_north'):
+        """Create an instance from a sparse sensor array.
+
+        Arguments:
+            dataset: Dataset following the `Arrays` convention, with
+                `surface_elevation` (time, element), `position_x` (element) and
+                `position_y` (element). Optional `eastward_slope` and
+                `northward_slope` (time, element) enable the Longuet-Higgins sign
+                fallback.
+            depth: Mean water depth in metres.
+            fs: Sampling frequency in Hz. If None, it is inferred from the time
+                coordinate or the `sampling_rate` attribute.
+            direction_convention: Either `cw_from_north` (default) or `math`.
+        """
+        return cls(dataset=dataset, depth=depth, fs=fs,
+                   direction_convention=direction_convention)
+
+
+    @classmethod
+    def from_numpy(cls, time, surface_elevation, position_x, position_y,
+                   depth, fs=None, **kwargs):
+        """Create an instance of a sparse array from numpy arrays.
+
+        This mirrors `Arrays.from_numpy`. The `surface_elevation` array has shape
+        (time, n_elements) and `position_x` and `position_y` have length
+        n_elements.
+        """
+        position_x = np.asarray(position_x)
+        position_y = np.asarray(position_y)
+        if len(position_x) != len(position_y):
+            raise ValueError("Number of elements in `x` and `y` are not consistent.")
+
+        # element numbering is always assumed from 0 to number of elements
+        elements = np.arange(len(position_x))
+
+        # create dataset from numpy arrays
+        dataset = xr.Dataset(
+            data_vars={
+                "surface_elevation": (["time", "element"], surface_elevation),
+                "position_x": ("element", position_x),
+                "position_y": ("element", position_y),
+            },
+            coords={"time": time, "element": elements},
+        )
+        return cls.from_arrays(dataset, depth=depth, fs=fs, **kwargs)
+
+
+    def _prepare_sparse(self, dataset):
+        """Validate a sparse dataset and derive its geometry."""
+
+        # the dataset must contain elevation and the element positions
+        for var in ("surface_elevation", "position_x", "position_y"):
+            if var not in dataset:
+                raise ValueError(f"`dataset` is missing the `{var}` variable.")
+
+        # determine the sampling frequency from the argument, the global
+        # attribute or the time coordinate, in that order
+        if self.fs is None:
+            self.fs = dataset.attrs.get("sampling_rate")
+        if self.fs is None:
+            self.fs = get_sampling_frequency(dataset["time"])
+        self.fs = float(self.fs)
+
+        # element positions and the pairwise baselines
+        self._px = dataset["position_x"].values.astype(float)
+        self._py = dataset["position_y"].values.astype(float)
+        b = np.hypot(self._px[:, None] - self._px[None, :],
+                     self._py[:, None] - self._py[None, :])
+
+        # the element span and the smallest non-zero baseline set the default
+        # grid bounds, since a sparse array has no pixel grid of its own
+        span = float(b.max())
+        bmin = float(b[b > 0].min()) if np.any(b > 0) else span
+        self.dx = bmin / 2.0
+        self._kfov = 2 * np.pi / span
+
+
+    def _sparse_apertures(self):
+        """Group elements into nested sub-apertures by baseline.
+
+        The sub-apertures are element subsets within a shrinking radius about the
+        array centroid, from coarse to tight, spaced by roughly a factor 1.3.
+        Each subset must have at least three non-collinear elements so that the
+        two-dimensional least-squares solve is well posed.
+        """
+        px, py = self._px, self._py
+        cx, cy = px.mean(), py.mean()
+        dist = np.hypot(px - cx, py - cy)
+        rmax = float(dist.max())
+        bmin = dist[dist > 0].min() if np.any(dist > 0) else 0.0
+
+        # shrink the radius and keep every subset with enough non-collinear
+        # elements, dropping duplicates of the previous subset
+        out, r, ai = [], rmax, 0
+        while r > 0:
+            idx = np.where(dist <= r * 1.0000001)[0]
+            if idx.size >= 3:
+                pts = np.c_[px[idx] - px[idx].mean(), py[idx] - py[idx].mean()]
+                if np.linalg.matrix_rank(pts, tol=1e-9) >= 2:
+                    if not out or set(idx) != set(out[-1][1]):
+                        out.append((f"A{ai}", idx))
+                        ai += 1
+            r /= 1.3
+            if r < bmin:
+                break
+
+        if not out:
+            raise ValueError(
+                "Sparse array has no aperture with at least three "
+                "non-collinear elements."
+            )
+        return out
+
+
+    def _build_apertures_field(self, freqs, apertures, n_staff, seed, omega0,
+                               solve_eta, lo_frac, lo_frac_broad, hi_frac,
+                               flip_dir):
+        """Seed virtual staffs and solve a wavevector for each aperture.
+
+        This is the dense-field path. It returns the list of per-aperture
+        dictionaries, the Longuet-Higgins reference direction, the footprint
+        variance and the time array.
+        """
+        eta = self.field
+        ny, nx, T = eta.shape
+        valid = self.valid
+
+        # variance over the whole frame, or over the footprint when one is given.
+        # in the latter case the staffs are drawn from a one-pixel-eroded mask so
+        # that the gradient central differences stay inside the footprint
+        if valid is None:
+            var_eta = float(eta.var(axis=2).mean())
+            seed_valid = None
+        else:
+            valid = np.asarray(valid, dtype=bool)
+            var_eta = float(np.nanmean(np.where(valid, eta.var(axis=2), np.nan)))
+            seed_valid = erode_valid(valid)
+        time = np.arange(T) / self.fs
+
+        # loop over the apertures, seeding the staffs and solving the wavevector
+        ap = []
+        a0_ij = None
+        for ai, (name, ext) in enumerate(apertures):
+            ii, jj, px, py, bmax = seed_aperture(ny, nx, self.dx, ext, n_staff,
+                                                 seed + ai, valid=seed_valid)
+            es = _bilinear_stack(eta, ii, jj)
+            es = es - es.mean(1, keepdims=True)
+            We = cwt_stack(es, freqs, self.fs, omega0)
+
+            # solve the wavevector on the optional de-pistoned field; the power
+            # is always taken from the wavelet coefficients of the elevation
+            if solve_eta is not None:
+                ek = _bilinear_stack(solve_eta, ii, jj)
+                Wk = cwt_stack(ek - ek.mean(1, keepdims=True), freqs, self.fs,
+                               omega0)
+            else:
+                Wk = We
+            kx, ky, resid, misfit = solve_wavevectors(Wk, px, py)
+
+            # the coarsest aperture uses the broad lower fraction to reach lower k
+            klo, khi = aperture_band(
+                bmax, lo_frac=(lo_frac_broad if ai == 0 else lo_frac),
+                hi_frac=hi_frac)
+            ap.append(dict(name=name, bmax=bmax, klo=klo, khi=khi,
+                           kmag=np.hypot(kx, ky), resid=resid, misfit=misfit, We=We,
+                           dir=_math_angle_to_cw_from_N(np.arctan2(ky, kx),
+                                                        flip=flip_dir),
+                           P=(np.abs(We)**2).mean(0)))
+            if ai == 0:
+                a0_ij = (ii, jj)
+
+        # Longuet-Higgins first moment from the coarsest aperture's staffs, using
+        # the spatial gradient as the local slope. `seed_aperture` uses an
+        # East/North frame (East = (cxp - j) dx, North = (cyp - i) dx) opposite to
+        # the pixel row/column indices, so the slopes must match:
+        # d/dEast = -d/d(col), d/dNorth = -d/d(row). Otherwise the heave-slope
+        # cross spectrum is sign-flipped and the resolved hemisphere is 180
+        # degrees from the measured wavevector.
+        gy, gx = np.gradient(eta, self.dx, axis=(0, 1))
+        gx, gy = -gx, -gy
+        ii, jj = a0_ij
+        sxs = np.stack([gx[i, j, :] for i, j in zip(ii, jj)])
+        sys = np.stack([gy[i, j, :] for i, j in zip(ii, jj)])
+        Wsx = cwt_stack(sxs - sxs.mean(1, keepdims=True), freqs, self.fs, omega0)
+        Wsy = cwt_stack(sys - sys.mean(1, keepdims=True), freqs, self.fs, omega0)
+        lh = lh_direction(ap[0]['We'], Wsx, Wsy, flip=flip_dir)
+        return ap, lh, var_eta, time
+
+
+    def _build_apertures_sparse(self, freqs, omega0, solve_eta, lo_frac,
+                                lo_frac_broad, hi_frac, flip_dir):
+        """Group elements into nested sub-apertures and solve a wavevector each.
+
+        This is the sparse-array path. It returns the same per-aperture
+        dictionaries, Longuet-Higgins reference, footprint variance and time
+        array as the dense-field path.
+        """
+        ds = self.dataset
+        elev = ds["surface_elevation"].transpose("element", "time").values
+        elev = elev.astype(float)
+        nelem, T = elev.shape
+        time = np.arange(T) / self.fs
+
+        # mean variance over the elements
+        var_eta = float(np.nanmean(np.nanvar(elev, axis=1)))
+
+        # optional de-pistoned solve field, in the same element ordering
+        if solve_eta is not None:
+            solve = np.asarray(solve_eta, dtype=float)
+            if solve.shape != elev.shape:
+                raise ValueError(
+                    "`solve_eta` must have shape (n_element, time)."
+                )
+        else:
+            solve = None
+
+        # loop over the baseline-grouped sub-apertures and solve the wavevector
+        groups = self._sparse_apertures()
+        ap, a0_idx = [], None
+        for ai, (name, idx) in enumerate(groups):
+            px, py = self._px[idx], self._py[idx]
+            bmax = float(np.hypot(px[:, None] - px[None, :],
+                                  py[:, None] - py[None, :]).max())
+            es = elev[idx] - elev[idx].mean(1, keepdims=True)
+            We = cwt_stack(es, freqs, self.fs, omega0)
+            if solve is not None:
+                ek = solve[idx] - solve[idx].mean(1, keepdims=True)
+                Wk = cwt_stack(ek, freqs, self.fs, omega0)
+            else:
+                Wk = We
+            kx, ky, resid, misfit = solve_wavevectors(Wk, px, py)
+            klo, khi = aperture_band(
+                bmax, lo_frac=(lo_frac_broad if ai == 0 else lo_frac),
+                hi_frac=hi_frac)
+            ap.append(dict(name=name, bmax=bmax, klo=klo, khi=khi,
+                           kmag=np.hypot(kx, ky), resid=resid, misfit=misfit, We=We,
+                           dir=_math_angle_to_cw_from_N(np.arctan2(ky, kx),
+                                                        flip=flip_dir),
+                           P=(np.abs(We)**2).mean(0)))
+            if ai == 0:
+                a0_idx = idx
+
+        # the Longuet-Higgins sign fallback is only available when co-located
+        # slopes are present in the dataset; otherwise the caller must resolve
+        # the sign through the `sign_anchor` hook
+        if "eastward_slope" in ds and "northward_slope" in ds:
+            sx = ds["eastward_slope"].transpose("element", "time").values[a0_idx]
+            sy = ds["northward_slope"].transpose("element", "time").values[a0_idx]
+            Wsx = cwt_stack(sx - sx.mean(1, keepdims=True), freqs, self.fs, omega0)
+            Wsy = cwt_stack(sy - sy.mean(1, keepdims=True), freqs, self.fs, omega0)
+            lh = lh_direction(ap[0]['We'], Wsx, Wsy, flip=flip_dir)
+        else:
+            logger.warning(
+                "Sparse array has no `eastward_slope` or `northward_slope`, so "
+                "the Longuet-Higgins sign fallback is unavailable. Pass a "
+                "`sign_anchor` to resolve the 180-degree ambiguity."
+            )
+            lh = None
+        return ap, lh, var_eta, time
+
+
+    def _run_multiaperture(self, ap, lh, var_eta, time, freqs, k_grid, nu_grid,
+                           dd, kappa, rel_bandwidth, radial_bandwidth_mode,
+                           power_weighted, nu_lo_broad, nu_f_lim, nu_k_lim,
+                           stitch_taper, antialias_gate, antialias_mult,
+                           sign_anchor, sign_anchor_rmin, sign_coh_min,
+                           reliability_gate):
+        """Resolve the sign, gate and stitch the per-aperture solutions.
+
+        This is the common estimator shared by both input modes. It works only on
+        the assembled per-aperture dictionaries and returns a dictionary of the
+        composite spectra and diagnostics.
+        """
+        depth = self.depth
+        coords = {'frequency': freqs, 'time': time}
+
+        # sign reference theta(f): per-frequency axis from the energy-weighted
+        # measured wavevector (smoothed double-angle mean), unwrapped across
+        # frequency into a signed direction, with the global sign set from the
+        # anchor or, failing that, the energy-weighted Longuet-Higgins hemisphere
+        P0 = ap[0]['P']
+        dir0 = ap[0]['dir']
+        wf = P0.mean(1)
+        ca = (P0 * np.cos(np.radians(2 * dir0))).sum(1)
+        sa = (P0 * np.sin(np.radians(2 * dir0))).sum(1)
+        R2 = np.hypot(ca, sa) / np.maximum(P0.sum(1), 1e-30)   # axis coherence
+        sm = np.array([0.25, 0.5, 0.25])
+        axis = np.degrees(np.arctan2(np.convolve(sa, sm, mode='same'),
+                                     np.convolve(ca, sm, mode='same'))) / 2.0
+
+        # pick whichever of the two axis branches is closest to the running value
+        def _branch(a, prev):
+            c1, c2 = _wrap180(a), _wrap180(a + 180.0)
+            return c1 if abs(_wrap180(c1 - prev)) <= abs(_wrap180(c2 - prev)) else c2
+
+        # seed the unwrap at the spectral peak and propagate outward. above the
+        # peak the axis is always unwrapped; below the peak only the coherent
+        # frequencies update the running direction, the incoherent ones hold it
+        pk = int(np.argmax(wf))
+        theta = np.empty(len(freqs))
+        cur = axis[pk]
+        theta[pk] = cur
+        for i in range(pk + 1, len(freqs)):
+            cur = _branch(axis[i], cur)
+            theta[i] = cur
+        cur = theta[pk]
+        for i in range(pk - 1, -1, -1):
+            if R2[i] >= sign_coh_min:
+                cur = _branch(axis[i], cur)
+            theta[i] = cur
+
+        # energy-weighted circular mean of a set of directions
+        def _ewmean(deg, w):
+            return np.degrees(np.arctan2((w * np.sin(np.radians(deg))).sum(),
+                                         (w * np.cos(np.radians(deg))).sum()))
+
+        # set the global sign from the external anchor when it is reliable, then
+        # from the Longuet-Higgins direction, and otherwise leave the axis as is
+        if sign_anchor is not None and (
+                np.isfinite(np.asarray(sign_anchor[1], float))
+                & (np.asarray(sign_anchor[2], float) >= sign_anchor_rmin)).any():
+            af, ad, aR = (np.asarray(x, float) for x in sign_anchor)
+            ok = np.isfinite(ad) & (aR >= sign_anchor_rmin)
+            jc = np.argmin(np.abs(af[ok, None] - freqs[None, :]), axis=1)
+            w = aR[ok] * wf[jc]
+            flip = np.cos(np.radians(_ewmean(theta[jc], w) - _ewmean(ad[ok], w))) < 0
+        elif lh is not None:
+            flip = np.cos(np.radians(_ewmean(theta, wf) - _ewmean(lh, wf))) < 0
+        else:
+            flip = False
+        ref = _wrap180(theta + 180.0) if flip else theta
+
+        # fold every aperture's direction into the signed hemisphere
+        def _fold(dir_cwN):
+            mis = np.cos(np.radians(dir_cwN - ref[:, None])) < 0
+            return np.where(mis, _wrap180(dir_cwN + 180.0), dir_cwN)
+        for d in ap:
+            d['dirf'] = _fold(d['dir'])
+
+        # one variance calibration from the full-frame power so that the integral
+        # of S(f) over frequency equals the elevation variance
+        cal = var_eta / _trapezoid(ap[0]['P'].mean(1), freqs)
+
+        # anti-alias gate threshold (see the `compute` docstring)
+        kdisp = k_dispersion(freqs, depth)
+        gate_k = antialias_mult * float(k_dispersion(freqs[pk], depth))
+
+        # the Q(nu) deposit is restricted to a trusted scale window from the array
+        # baselines, with a high cut at the frame-fundamental wavenumber, and the
+        # matching dispersion band in frequency. Only Q(nu) is gated this way
+        bmx = [d['bmax'] for d in ap]
+        if nu_k_lim == 'auto':
+            nu_k_lim = (2 * np.pi / (50.0 * max(bmx)), self._kfov)
+        if nu_f_lim == 'auto':
+            _fk = lambda kk: float(np.sqrt(
+                GRAV * kk * np.tanh(np.clip(kk * depth, 1e-9, 50)))
+                / (2 * np.pi))
+            nu_f_lim = ((_fk(nu_k_lim[0]), _fk(nu_k_lim[1]))
+                        if nu_k_lim is not None else None)
+
+        # accumulate the stitched wavenumber and inverse phase speed spectra
+        bins_dir = np.arange(-180.0, 180.0, dd)
+        Fk = np.zeros(len(k_grid)); ck = np.zeros(len(k_grid))
+        Qn = np.zeros(len(nu_grid)); cn = np.zeros(len(nu_grid))
+        Fkd = np.zeros((len(k_grid), len(bins_dir)))
+        Qnd = np.zeros((len(nu_grid), len(bins_dir)))
+        Ffd = None        # stitched frequency-direction deposit (filled in loop)
+        ap_ok_omni = []   # per-aperture omnidirectional F(k), for diagnostics
+        for d in ap:
+            # anti-alias frequency mask: send the frequencies that would alias off
+            # the k and nu grids so they never deposit, while keeping the power
+            # intact so the power-weighting is undisturbed
+            fok = (kdisp <= d['khi']) if (antialias_gate and d['khi'] < gate_k) \
+                else np.ones(len(freqs), bool)
+            # dispersion-independent reliability mask: drop (freq, time) samples
+            # whose least-squares phase misfit is high (a short wave aliased by
+            # this aperture, or noise) so their spurious low wavenumber never
+            # deposits. The power is kept intact, so the power-weighting is
+            # undisturbed. On by default (reliability_gate=0.6); None disables it.
+            relok = (d['misfit'] <= reliability_gate) \
+                if reliability_gate is not None else np.ones_like(d['kmag'], bool)
+            power = xr.DataArray(d['P'] * cal, dims=['frequency', 'time'],
+                                 coords=coords)
+            thd = xr.DataArray(d['dirf'], dims=['frequency', 'time'],
+                               coords=coords)
+
+            # deposit onto the wavenumber grid
+            k_vals = np.where(fok[:, None] & relok, d['kmag'], 1e12)
+            kk = xr.DataArray(k_vals, dims=['frequency', 'time'], coords=coords)
+            ok = estimate_radial_distribution(power, thd, kk, 'wavenumber',
+                                              k_grid, dd, kappa,
+                                              bandwidth=rel_bandwidth,
+                                              bandwidth_mode=radial_bandwidth_mode,
+                                              power_weighted=power_weighted)
+
+            # deposit onto the inverse phase speed grid, gated to the trusted
+            # (f, k) window. out-of-window samples are sent off the nu grid, again
+            # keeping the power intact so F(k) and S(f) are unaffected
+            nu_vals = d['kmag'] / (2 * np.pi * freqs[:, None])
+            if nu_f_lim is not None or nu_k_lim is not None:
+                keep = np.ones(nu_vals.shape, bool)
+                if nu_f_lim is not None:
+                    keep &= ((freqs >= nu_f_lim[0]) & (freqs <= nu_f_lim[1]))[:, None]
+                if nu_k_lim is not None:
+                    keep &= (d['kmag'] >= nu_k_lim[0]) & (d['kmag'] <= nu_k_lim[1])
+                nu_vals = np.where(keep, nu_vals, 1e6)
+            nu_vals = np.where(fok[:, None] & relok, nu_vals, 1e12)
+            nu = xr.DataArray(nu_vals, dims=['frequency', 'time'], coords=coords)
+            on = estimate_radial_distribution(power, thd, nu, 'nu', nu_grid,
+                                              dd, kappa, bandwidth=rel_bandwidth,
+                                              bandwidth_mode=radial_bandwidth_mode,
+                                              power_weighted=power_weighted)
+
+            ok_omni = ok['wavenumber_spectrum'].values
+            ok_dir = ok['directional_spectrum'].values
+            on_omni = on['nu_spectrum'].values
+            on_dir = on['directional_spectrum'].values
+
+            # the nu band follows the aperture's k-band along the dispersion
+            # relation; the broadest aperture is extended down to `nu_lo_broad` to
+            # show the measured inverse phase speed tail
+            ink = (k_grid >= d['klo']) & (k_grid <= d['khi'])
+            nlo, nhi = _nu_of_k(d['khi'], depth), _nu_of_k(d['klo'], depth)
+            lo = min(nlo, nhi)
+            if d is ap[0]:
+                lo = min(lo, nu_lo_broad)
+
+            # stitch weights: a cosine edge taper in log-k and log-nu when one is
+            # requested, otherwise the hard in-band indicator. The weight cancels
+            # in the single-aperture regions
+            wk = _log_edge_taper(k_grid, d['klo'], d['khi'], stitch_taper) \
+                if stitch_taper else ink.astype(float)
+            wn = _log_edge_taper(nu_grid, lo, max(nlo, nhi), stitch_taper) \
+                if stitch_taper else \
+                ((nu_grid >= lo) & (nu_grid <= max(nlo, nhi))).astype(float)
+
+            ap_ok_omni.append((ok_omni.copy(), ink.copy()))
+            Fk += ok_omni * wk; ck += wk
+            Fkd += ok_dir * wk[:, None]
+            Qn += on_omni * wn; cn += wn
+            Qnd += on_dir * wn[:, None]
+
+            # stitched frequency-direction deposit (dispersion-free): this
+            # aperture contributes E(f, theta) from its reliable, non-aliased
+            # samples only (the `relok` phase-misfit gate). summed over apertures,
+            # each frequency takes its direction from whichever apertures resolve
+            # it, so the coarsest aperture's aliased high-frequency direction does
+            # not flip the estimate.
+            pgd = xr.DataArray(d['P'] * cal * relok, dims=['frequency', 'time'],
+                               coords=coords)
+            ofd = estimate_directional_distribution(pgd, thd, dd, kappa)
+            Ffd = ofd['directional_spectrum'].values if Ffd is None \
+                else Ffd + ofd['directional_spectrum'].values
+
+        # normalise the stitched spectra by the accumulated weights
+        Fk = np.where(ck > 0, Fk / np.maximum(ck, 1e-30), np.nan)
+        Fkd /= np.maximum(ck, 1e-30)[:, None]
+        Qn = np.where(cn > 0, Qn / np.maximum(cn, 1e-30), np.nan)
+        Qnd /= np.maximum(cn, 1e-30)[:, None]
+
+        # frequency spectrum S(f) from the coarsest aperture: its power is valid
+        # at every frequency (only its direction aliases above the baseline
+        # limit). F(f, theta) is the reliability-stitched deposit, renormalised
+        # so it integrates over direction to S(f).
+        power0 = xr.DataArray(ap[0]['P'] * cal, dims=['frequency', 'time'],
+                              coords=coords)
+        theta0 = xr.DataArray(ap[0]['dirf'], dims=['frequency', 'time'],
+                              coords=coords)
+        of = estimate_directional_distribution(power0, theta0, dd, kappa)
+        Sf = of['frequency_spectrum'].values
+        thg = of['direction'].values
+        row = Ffd.sum(1) * np.radians(dd)
+        Fft = np.divide(Ffd, np.maximum(row, 1e-30)[:, None]) * Sf[:, None]
+        thbar, sigma = circ_stats(Fft, thg)
+
+        return dict(freqs=freqs, theta=thg, k=k_grid, nu=nu_grid,
+                    var_eta=var_eta, Sf=Sf, Fft=Fft, Fk=Fk, Qn=Qn, Fkd=Fkd,
+                    Qnd=Qnd, thbar=thbar, sigma=sigma,
+                    lh=(lh if lh is not None else np.full(len(freqs), np.nan)),
+                    sign_ref=ref, ap_names=[d['name'] for d in ap],
+                    ap_bands=[(d['klo'], d['khi']) for d in ap],
+                    ap_bmax=[d['bmax'] for d in ap],
+                    ap_ok_omni=ap_ok_omni, ck=ck)
+
+
+    def compute(self, *, freqs=None, k_grid=None, nu_grid=None,
+                apertures=None, n_staff=16, seed=20,
+                dd=4.0, kappa=36.0, omega0=12.0,
+                lo_frac=1.0, lo_frac_broad=0.05, hi_frac=1.0, flip_dir=False,
+                rel_bandwidth=0.08, radial_bandwidth_mode='relative',
+                power_weighted=True, nu_lo_broad=0.04,
+                nu_f_lim='auto', nu_k_lim='auto',
+                stitch_taper=0.7, solve_eta=None, depiston=False,
+                antialias_gate=False, antialias_mult=3.0,
+                reliability_gate=0.6,
+                sign_anchor=None, sign_anchor_rmin=0.15, sign_coh_min=0.6,
+                return_apertures=False) -> xr.Dataset:
+        """Perform the multi-aperture computation.
+
+        The result is a dataset with the omnidirectional spectra S(f), F(k) and
+        Q(nu), the polar directional spectra F(f, theta), Psi(k, theta) and
+        Q(nu, theta), and the mean direction, directional spread, Longuet-Higgins
+        reference and unwrapped sign reference. The direction is in degrees
+        clockwise from North unless the instance was built with
+        `direction_convention="math"`.
+
+        Args:
+            freqs, k_grid, nu_grid (np.ndarray, optional): Log-spaced radial
+                grids. When None they default to `default_grids`; the sparse path
+                derives the pixel-Nyquist ceiling from the smallest baseline, so
+                explicit grids are recommended for a sparse array.
+            apertures (list, optional): List of (name, extent) tuples for the
+                dense path, where the extent is a window side in pixels (a scalar
+                square or a (rows, cols) tuple) or ("plus", arm_px) for a cross
+                aperture. Defaults to `auto_apertures`, a data-aware ladder sized
+                to the field of view (coarse windows down to tight crosses), so
+                the stitched spectrum spans the full wavenumber range without
+                hand-tuning. Ignored for a sparse array, whose sub-apertures are
+                grouped by baseline.
+            n_staff (int): Number of virtual staffs per aperture (dense path).
+            seed (int): Seed for the random staff placement (dense path).
+            dd (float): Directional resolution in degrees (default 4 degrees).
+            kappa (float): Smoothness parameter of the von Mises kernel.
+            omega0 (float): Morlet central frequency.
+            lo_frac, lo_frac_broad, hi_frac (float): Trusted-band fractions. The
+                coarsest aperture uses `lo_frac_broad` to reach lower wavenumbers.
+            flip_dir (bool): Globally flip the measured direction convention.
+            rel_bandwidth (float): Radial kernel width forwarded to
+                `estimate_radial_distribution`.
+            radial_bandwidth_mode (str): Radial kernel mode, one of `relative`
+                (a log-space fractional width), `histogram` or `absolute`.
+            power_weighted (bool): Bin the variance rather than the sample
+                occurrence into F(k) and Q(nu).
+            nu_lo_broad (float): Extend the coarsest aperture's Q(nu) band down to
+                this inverse phase speed to show the measured tail.
+            nu_f_lim, nu_k_lim (str, tuple or None): Gates applied only to Q(nu).
+                `auto` derives them from the array baselines, with the high cut at
+                the frame-fundamental wavenumber. A tuple overrides them and None
+                disables a gate.
+            stitch_taper (float): Cosine edge-taper width in octaves blending the
+                overlapping aperture bands. Zero or None gives a hard in-band
+                indicator.
+            solve_eta (np.ndarray, optional): Field or array, the same shape as
+                the elevation, used only for the wavevector solve. The power and
+                variance still come from the elevation. Pass a de-pistoned field
+                to keep the uniform long wave out of the cross-staff phases.
+            depiston (bool): Built-in de-piston. When True (and `solve_eta` is
+                not given), the per-frame spatial mean is removed from a copy of
+                the field used only for the wavevector solve, suppressing the
+                residual low-wavenumber bias from waves longer than the footprint
+                (which the reliability gate cannot catch, since their phase
+                differences are small but consistent). Default False; enable for
+                field-of-view-limited data where the dominant wave approaches or
+                exceeds the footprint.
+            antialias_gate (bool): When True, an aperture whose ceiling is below
+                `antialias_mult` times the spectral peak wavenumber deposits onto
+                the k and nu grids only the frequencies whose dispersion
+                wavenumber is below the ceiling. S(f) and F(f, theta) are
+                unaffected. Enable this when the widest baseline exceeds the
+                dominant wavelength.
+            antialias_mult (float): Multiple of the peak wavenumber above which an
+                aperture is considered safe from aliasing.
+            reliability_gate (float or None): The default low-k guard. Drops
+                every (frequency, time) sample whose normalised least-squares
+                phase misfit (see :func:`solve_wavevectors`) exceeds this
+                threshold before it is binned, so short waves aliased by an
+                over-large aperture do not deposit their spurious low wavenumber.
+                The misfit separates cleanly-resolved samples (-> 0) from aliased
+                or noisy ones (-> 1), so the gate removes only the unreliable
+                samples. It makes no dispersion assumption, so it also handles
+                bound waves or a Doppler-shifted sea. Default ``0.6``; set to None
+                to disable. S(f)/F(f, theta) are unaffected.
+            sign_anchor (tuple, optional): External (frequency, direction, R)
+                estimate resolving the 180-degree ambiguity, for example from a
+                3D FFT. It overrides the Longuet-Higgins fallback.
+            sign_anchor_rmin (float): Reliability floor for the anchor.
+            sign_coh_min (float): Coherence gate for the below-peak sign unwrap.
+            return_apertures (bool): Attach the per-aperture diagnostics on an
+                `aperture` dimension.
+
+        Returns:
+            xr.Dataset: Dataset containing the omnidirectional and directional
+            spectra and the directional diagnostics.
+        """
+
+        # default radial grids when none are supplied
+        if freqs is None or k_grid is None or nu_grid is None:
+            df, dk, dn = default_grids(self.dx)
+            freqs = df if freqs is None else freqs
+            k_grid = dk if k_grid is None else k_grid
+            nu_grid = dn if nu_grid is None else nu_grid
+        freqs = np.asarray(freqs, float)
+        k_grid = np.asarray(k_grid, float)
+        nu_grid = np.asarray(nu_grid, float)
+
+        # built-in de-piston: when requested and no explicit solve field is
+        # given, remove the per-frame spatial mean (the uniform "piston" mode of
+        # waves longer than the footprint) from a copy used only for the
+        # wavevector solve. targets the residual low-wavenumber bias the
+        # reliability gate cannot reach (a sub-footprint wave gives small but
+        # consistent phase differences with |k| biased towards zero).
+        if depiston and solve_eta is None:
+            if self.mode == "field":
+                f = self.field
+                if self.valid is not None:
+                    masked = np.where(self.valid[:, :, None], f, np.nan)
+                    solve_eta = f - np.nanmean(masked, axis=(0, 1), keepdims=True)
+                else:
+                    solve_eta = f - f.mean(axis=(0, 1), keepdims=True)
+            else:
+                elev = self.dataset["surface_elevation"].transpose(
+                    "element", "time").values.astype(float)
+                solve_eta = elev - elev.mean(0, keepdims=True)
+
+        # build the per-aperture solutions for the chosen input mode
+        if self.mode == "field":
+            if apertures is None:
+                ny, nx = self.field.shape[:2]
+                apertures = auto_apertures(ny, nx, self.dx)
+            ap, lh, var_eta, time = self._build_apertures_field(
+                freqs, apertures, n_staff, seed, omega0, solve_eta,
+                lo_frac, lo_frac_broad, hi_frac, flip_dir)
+        else:
+            if apertures is not None:
+                logger.warning(
+                    "`apertures` is ignored for a sparse array; the "
+                    "sub-apertures are grouped by baseline."
+                )
+            ap, lh, var_eta, time = self._build_apertures_sparse(
+                freqs, omega0, solve_eta, lo_frac, lo_frac_broad, hi_frac,
+                flip_dir)
+            if len(ap) == 1:
+                logger.warning(
+                    "Sparse array yielded a single aperture, so the result "
+                    "degenerates to a single-aperture solve."
+                )
+
+        # run the common estimator and wrap the result into a dataset
+        result = self._run_multiaperture(
+            ap, lh, var_eta, time, freqs, k_grid, nu_grid, dd, kappa,
+            rel_bandwidth, radial_bandwidth_mode, power_weighted, nu_lo_broad,
+            nu_f_lim, nu_k_lim, stitch_taper, antialias_gate, antialias_mult,
+            sign_anchor, sign_anchor_rmin, sign_coh_min, reliability_gate)
+
+        return self._to_dataset(
+            result, return_apertures=return_apertures, n_staff=n_staff,
+            seed=seed, omega0=omega0, kappa=kappa, dd=dd, lo_frac=lo_frac,
+            lo_frac_broad=lo_frac_broad, hi_frac=hi_frac,
+            stitch_taper=stitch_taper, antialias_gate=antialias_gate,
+            antialias_mult=antialias_mult, power_weighted=power_weighted,
+            radial_bandwidth_mode=radial_bandwidth_mode,
+            rel_bandwidth=rel_bandwidth)
+
+
+    def _to_dataset(self, r, *, return_apertures, **attrs):
+        """Wrap the estimator result dictionary into a labelled dataset."""
+
+        # the engine works in degrees clockwise from North. when the math angle
+        # convention is requested the direction coordinate and the per-frequency
+        # direction diagnostics are remapped, and the dataset is later sorted
+        direction = r['theta'].astype(float)
+        freq_dir = (r['thbar'], r['sigma'], r['lh'], r['sign_ref'])
+        if self.direction_convention == 'math':
+            direction = _cw_from_N_to_math_angle(direction)
+            freq_dir = tuple(_cw_from_N_to_math_angle(a) for a in freq_dir)
+        thbar, sigma, lh, sign_ref = freq_dir
+
+        # assemble the data variables and coordinates
+        data_vars = {
+            "frequency_spectrum": (["frequency"], r['Sf']),
+            "wavenumber_spectrum": (["wavenumber"], r['Fk']),
+            "nu_spectrum": (["nu"], r['Qn']),
+            "directional_spectrum_f": (["frequency", "direction"], r['Fft']),
+            "directional_spectrum_k": (["wavenumber", "direction"], r['Fkd']),
+            "directional_spectrum_nu": (["nu", "direction"], r['Qnd']),
+            "mean_direction": (["frequency"], thbar),
+            "directional_spread": (["frequency"], sigma),
+            "lh_direction": (["frequency"], lh),
+            "sign_reference": (["frequency"], sign_ref),
+            "var_eta": ((), r['var_eta']),
+        }
+        coords = {
+            "frequency": r['freqs'],
+            "wavenumber": r['k'],
+            "nu": r['nu'],
+            "direction": direction,
+        }
+        ds = xr.Dataset(data_vars=data_vars, coords=coords)
+        if self.direction_convention == 'math':
+            ds = ds.sortby("direction")
+
+        # attach the variable metadata
+        for coord in ("frequency", "wavenumber", "nu", "direction"):
+            if coord in VARIABLE_NAMES:
+                ds[coord].attrs = VARIABLE_NAMES[coord]
+        for var in ds.data_vars:
+            if var in VARIABLE_NAMES:
+                ds[var].attrs = VARIABLE_NAMES[var]
+
+        # optional per-aperture diagnostics on an aperture dimension
+        if return_apertures:
+            nap = len(r['ap_names'])
+            ap_fk = np.stack([o for o, _ in r['ap_ok_omni']])
+            ds = ds.assign_coords(aperture=np.arange(nap))
+            ds["aperture_name"] = ("aperture", np.array(r['ap_names'], dtype="U8"))
+            ds["aperture_bmax"] = ("aperture", np.asarray(r['ap_bmax']))
+            ds["aperture_klo"] = ("aperture",
+                                  np.array([b[0] for b in r['ap_bands']]))
+            ds["aperture_khi"] = ("aperture",
+                                  np.array([b[1] for b in r['ap_bands']]))
+            ds["aperture_Fk"] = (["aperture", "wavenumber"], ap_fk)
+            ds["stitch_weight_k"] = (["wavenumber"], r['ck'])
+
+        # global attributes, casting booleans and None to netcdf-safe scalars
+        safe = {"method": "multiaperture EWDM",
+                "mode": self.mode,
+                "depth": self.depth,
+                "dx": float(self.dx),
+                "fs": float(self.fs),
+                "direction_convention": self.direction_convention}
+        for key, value in attrs.items():
+            if isinstance(value, bool):
+                value = int(value)
+            elif value is None:
+                value = "None"
+            safe[key] = value
+        ds.attrs = safe
+        return ds
+# }}}

--- a/ewdm/parameters.py
+++ b/ewdm/parameters.py
@@ -57,6 +57,46 @@ VARIABLE_NAMES = {
          'long_name': 'Omnidirectional inverse-phase-speed wave spectrum Q(nu)',
          'units': 'm^3/s'
      },
+     'directional_spectrum_f': {
+         'standard_name': 'sea_surface_directional_wave_spectrum',
+         'long_name': 'Directional wave energy density spectrum F(f, theta)',
+         'units': 'm^2/Hz/degrees'
+     },
+     'directional_spectrum_k': {
+         'standard_name': 'sea_surface_wavenumber_directional_wave_spectrum',
+         'long_name': 'Directional wavenumber wave spectrum Psi(k, theta)',
+         'units': 'm^4/rad'
+     },
+     'directional_spectrum_nu': {
+         'standard_name': 'sea_surface_inverse_phase_speed_directional_wave_spectrum',
+         'long_name': 'Directional inverse-phase-speed wave spectrum Q(nu, theta)',
+         'units': 'm^4/(s^2 rad)'
+     },
+     'mean_direction': {
+         'standard_name': 'sea_surface_wave_mean_direction',
+         'long_name': 'Energy-weighted mean wave direction',
+         'units': 'degrees'
+     },
+     'directional_spread': {
+         'standard_name': 'sea_surface_wave_directional_spread',
+         'long_name': 'Energy-weighted directional spread',
+         'units': 'degrees'
+     },
+     'lh_direction': {
+         'standard_name': 'sea_surface_wave_longuet_higgins_direction',
+         'long_name': 'Longuet-Higgins first-moment mean direction',
+         'units': 'degrees'
+     },
+     'sign_reference': {
+         'standard_name': 'sea_surface_wave_sign_reference_direction',
+         'long_name': 'Unwrapped sign-reference direction',
+         'units': 'degrees'
+     },
+     'var_eta': {
+         'standard_name': 'sea_surface_elevation_variance',
+         'long_name': 'Sea surface elevation variance (m0)',
+         'units': 'm^2'
+     },
     'surface_elevation': {
         'standard_name': 'sea_surface_wave_elevation',
         'long_name': 'Sea surface wave elevation',

--- a/tests/test_multiaperture.py
+++ b/tests/test_multiaperture.py
@@ -1,0 +1,427 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Copyright © 2024 Daniel Pelaez-Zapata <http://github.com/dspelaez>
+Distributed under terms of the GNU/GPL 3.0 license.
+
+Tests for the multi-aperture estimator `MultiApertureArrays`. Both input
+modes are exercised: the dense elevation field, from which virtual staffs are
+seeded into nested apertures, and the sparse sensor array, whose sub-apertures
+are grouped by baseline. The wavenumber and inverse-phase-speed (nu) spectra
+follow Björkqvist et al. (2019).
+"""
+
+import numpy as np
+import pytest
+
+import ewdm
+from ewdm import MultiApertureArrays
+from ewdm.multiaperture import _cw_from_N_to_math_angle
+
+# numpy 2.0 renamed np.trapz to np.trapezoid; support both in tests.
+_trapezoid = getattr(np, "trapezoid", getattr(np, "trapz", None))
+
+
+GRAV = 9.8
+
+
+def _wavenumber(f0, depth):
+    """Finite-depth linear wavenumber, solved iteratively."""
+    omega = 2 * np.pi * f0
+    k = omega**2 / GRAV
+    for _ in range(100):
+        k = omega**2 / (GRAV * np.tanh(k * depth))
+    return k
+
+
+def _monochromatic_field(f0=0.25, direction_deg=40.0, amplitude=0.5,
+                         dx=1.0, fs=4.0, ny=48, nx=48, duration=128.0,
+                         depth=100.0):
+    """Build a dense plane-wave elevation field.
+
+    Returns the field together with the true wavenumber and inverse phase speed
+    so the tests can check the peak locations. The window is a few wavelengths
+    wide so the coarse apertures alias the wave, which is the regime the
+    anti-alias gate is meant to handle.
+    """
+    omega = 2 * np.pi * f0
+    k0 = _wavenumber(f0, depth)
+    theta = np.radians(direction_deg)
+    kx0, ky0 = k0 * np.cos(theta), k0 * np.sin(theta)
+
+    T = int(duration * fs)
+    t = np.arange(T) / fs
+    # build the wave in the same East/North frame as `seed_aperture`
+    # (East = (cxp - j) dx, North = (cyp - i) dx), so the planted propagation
+    # direction is exactly `direction_deg` in math angle
+    cxp, cyp = (nx - 1) / 2, (ny - 1) / 2
+    east = (cxp - np.arange(nx))[None, :, None] * dx
+    north = (cyp - np.arange(ny))[:, None, None] * dx
+    eta = amplitude * np.cos(kx0 * east + ky0 * north - omega * t[None, None, :])
+    return eta, k0, k0 / omega
+
+
+def _ring_array(rings=(3.0, 6.0, 10.0, 15.0), n_azimuth=6):
+    """Concentric-ring sparse array with a centre element."""
+    px, py = [0.0], [0.0]
+    for r in rings:
+        for a in np.linspace(0, 2 * np.pi, n_azimuth, endpoint=False):
+            px.append(r * np.cos(a))
+            py.append(r * np.sin(a))
+    return np.array(px), np.array(py)
+
+
+def _sparse_monochromatic(f0=0.12, direction_deg=30.0, amplitude=0.4,
+                          fs=4.0, duration=256.0, depth=100.0):
+    """Plane wave sampled at the concentric-ring array elements."""
+    px, py = _ring_array()
+    omega = 2 * np.pi * f0
+    k0 = _wavenumber(f0, depth)
+    theta = np.radians(direction_deg)
+    kx0, ky0 = k0 * np.cos(theta), k0 * np.sin(theta)
+    T = int(duration * fs)
+    t = np.arange(T) / fs
+    elev = np.stack(
+        [amplitude * np.cos(kx0 * x + ky0 * y - omega * t)
+         for x, y in zip(px, py)],
+        axis=-1
+    )
+    return t, elev, px, py, k0, k0 / omega
+
+
+# common compute settings: an explicit frequency grid below the Nyquist and the
+# anti-alias gate on, as the dense field aliases the short test wave
+FREQS = np.logspace(np.log10(0.06), np.log10(1.9), 52)
+DENSE = dict(seed=1, n_staff=12, freqs=FREQS, antialias_gate=True)
+
+
+def test_field_schema_and_units():
+    """The dense path should return the documented variables and units."""
+    eta, _, _ = _monochromatic_field()
+    spec = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0)
+    out = spec.compute(**DENSE)
+
+    for var in ("frequency_spectrum", "wavenumber_spectrum", "nu_spectrum",
+                "directional_spectrum_f", "directional_spectrum_k",
+                "directional_spectrum_nu", "mean_direction",
+                "directional_spread", "sign_reference", "var_eta"):
+        assert var in out
+
+    assert out["directional_spectrum_f"].dims == ("frequency", "direction")
+    assert out["directional_spectrum_k"].dims == ("wavenumber", "direction")
+    assert out["directional_spectrum_nu"].dims == ("nu", "direction")
+    assert out["wavenumber"].attrs["units"] == "rad/m"
+    assert out["nu"].attrs["units"] == "s/m"
+    assert out["directional_spectrum_k"].attrs["units"] == "m^4/rad"
+    assert out["directional_spectrum_nu"].attrs["units"] == "m^4/(s^2 rad)"
+    assert out.attrs["method"] == "multiaperture EWDM"
+    assert out.attrs["mode"] == "field"
+
+
+def test_field_variance_calibrated():
+    """The integral of S(f) over frequency should equal the field variance."""
+    eta, _, _ = _monochromatic_field()
+    out = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0,
+                                         fs=4.0).compute(**DENSE)
+    var_eta = float(out["var_eta"])
+    m0 = _trapezoid(out["frequency_spectrum"].values, out["frequency"].values)
+    assert np.isclose(m0, var_eta, rtol=1e-6)
+    # the plane-wave variance is amplitude**2 / 2
+    assert np.isclose(var_eta, 0.5**2 / 2, rtol=0.05)
+
+
+def test_field_wavenumber_peak():
+    """The wavenumber spectrum should peak near the true wavenumber."""
+    eta, k0, _ = _monochromatic_field()
+    out = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0,
+                                         fs=4.0).compute(**DENSE)
+    k = out["wavenumber"].values
+    Fk = out["wavenumber_spectrum"].values
+    k_peak = k[np.nanargmax(Fk)]
+    assert abs(k_peak - k0) / k0 < 0.15
+
+
+def test_field_nu_peak():
+    """The nu spectrum should peak near k0 / omega0 with the gates disabled."""
+    eta, _, nu0 = _monochromatic_field()
+    out = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0).compute(
+        nu_f_lim=None, nu_k_lim=None, **DENSE)
+    nu = out["nu"].values
+    Q = out["nu_spectrum"].values
+    nu_peak = nu[np.nanargmax(Q)]
+    assert abs(nu_peak - nu0) / nu0 < 0.15
+
+
+def test_direction_conventions_consistent():
+    """The math and compass conventions must be an exact transform of one
+    another, and both must recover the planted direction."""
+    eta, _, _ = _monochromatic_field(direction_deg=40.0)
+    out_cw = MultiApertureArrays.from_field(
+        eta, dx=1.0, depth=100.0, fs=4.0,
+        direction_convention="cw_from_north").compute(**DENSE)
+    out_math = MultiApertureArrays.from_field(
+        eta, dx=1.0, depth=100.0, fs=4.0,
+        direction_convention="math").compute(**DENSE)
+
+    fpk = np.nanargmax(out_cw["frequency_spectrum"].values)
+    dir_cw = out_cw["mean_direction"].values[fpk]
+    dir_math = out_math["mean_direction"].values[fpk]
+
+    # math angle 40 deg corresponds to 50 deg clockwise from North
+    assert abs(((dir_cw - 50.0 + 180) % 360) - 180) < 12.0
+    # the two conventions are the exact analytic transform of each other
+    assert np.isclose(_cw_from_N_to_math_angle(dir_cw), dir_math, atol=1e-6)
+
+
+def test_antialias_gate_removes_lowk_pileup():
+    """Without the gate the aliased coarse apertures pile energy at low k; the
+    gate moves the peak back onto the true wavenumber."""
+    eta, k0, _ = _monochromatic_field()
+    spec = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0)
+    # disable the reliability gate (default on) to isolate the anti-alias gate
+    open_ = spec.compute(seed=1, n_staff=12, freqs=FREQS,
+                         antialias_gate=False, reliability_gate=None)
+    gated = spec.compute(seed=1, n_staff=12, freqs=FREQS,
+                         antialias_gate=True, reliability_gate=None)
+
+    k = gated["wavenumber"].values
+    k_open = k[np.nanargmax(open_["wavenumber_spectrum"].values)]
+    k_gated = k[np.nanargmax(gated["wavenumber_spectrum"].values)]
+    assert k_open < 0.5 * k0          # spurious low-k peak without the gate
+    assert abs(k_gated - k0) / k0 < 0.15
+
+
+def test_reliability_gate_removes_lowk_pileup():
+    """The dispersion-independent reliability gate removes the aliased low-k
+    pileup just like the anti-alias gate, recovering the true peak wavenumber."""
+    eta, k0, _ = _monochromatic_field()
+    spec = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0)
+    open_ = spec.compute(seed=1, n_staff=12, freqs=FREQS, reliability_gate=None)
+    gated = spec.compute(seed=1, n_staff=12, freqs=FREQS, reliability_gate=0.5)
+
+    k = gated["wavenumber"].values
+    k_open = k[np.nanargmax(open_["wavenumber_spectrum"].values)]
+    k_gated = k[np.nanargmax(gated["wavenumber_spectrum"].values)]
+    assert k_open < 0.5 * k0          # spurious low-k peak without any gate
+    assert abs(k_gated - k0) / k0 < 0.15
+
+
+def test_depiston_is_solve_only():
+    """Built-in de-piston changes only the wavevector solve, so the frequency
+    spectrum (and hence the variance) is left untouched."""
+    eta, _, _ = _monochromatic_field()
+    spec = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0)
+    base = spec.compute(**DENSE)
+    dep = spec.compute(depiston=True, **DENSE)
+    assert np.allclose(base["frequency_spectrum"].values,
+                       dep["frequency_spectrum"].values)
+    assert np.isfinite(dep["wavenumber_spectrum"].values).any()
+
+
+def test_solver_misfit_low_for_clean_wave():
+    """`solve_wavevectors` returns a misfit that is small for a cleanly resolved
+    plane wave (consistent phase differences across pairs)."""
+    from ewdm.multiaperture import solve_wavevectors, cwt_stack, seed_aperture
+    eta, k0, _ = _monochromatic_field()
+    ny, nx, _ = eta.shape
+    ii, jj, px, py, _ = seed_aperture(ny, nx, 1.0, 10, 12, 0)
+    es = np.stack([eta[i, j, :] for i, j in zip(ii, jj)])
+    W = cwt_stack(es - es.mean(1, keepdims=True), FREQS, 4.0, 12.0)
+    kx, ky, resid, misfit = solve_wavevectors(W, px, py)
+    # at the wave frequency the misfit should be small (well-resolved)
+    fi = np.argmin(np.abs(FREQS - 0.25))
+    assert np.nanmedian(misfit[fi]) < 0.3
+
+
+def test_stitch_no_interior_notch():
+    """The stitched F(k) must have no NaN or zero notch inside the band actually
+    covered by the apertures (where the stitch weight is non-zero)."""
+    eta, _, _ = _monochromatic_field()
+    out = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0).compute(
+        return_apertures=True, **DENSE)
+    Fk = out["wavenumber_spectrum"].values
+    ck = out["stitch_weight_k"].values
+    covered = ck > 1e-6
+    assert np.all(np.isfinite(Fk[covered]))
+    assert np.all(Fk[covered] > 0)
+
+
+def test_return_apertures_diagnostics():
+    """The per-aperture diagnostics should appear on an aperture dimension."""
+    eta, _, _ = _monochromatic_field()
+    out = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0).compute(
+        return_apertures=True, **DENSE)
+    assert "aperture" in out.dims
+    assert out["aperture_bmax"].dims == ("aperture",)
+    assert out["aperture_Fk"].dims == ("aperture", "wavenumber")
+    # the baselines should shrink from the coarsest to the tightest aperture
+    bmax = out["aperture_bmax"].values
+    assert bmax[0] > bmax[-1]
+
+
+def test_sparse_wavenumber_peak():
+    """The sparse path should recover the peak wavenumber of a plane wave."""
+    t, elev, px, py, k0, _ = _sparse_monochromatic()
+    spec = MultiApertureArrays.from_numpy(
+        time=t, surface_elevation=elev, position_x=px, position_y=py,
+        depth=100.0, fs=4.0)
+    k_grid = 2.0**np.linspace(np.log2(0.02), np.log2(1.0), 64)
+    nu_grid = 2.0**np.linspace(np.log2(0.02), np.log2(2.0), 64)
+    out = spec.compute(freqs=FREQS, k_grid=k_grid, nu_grid=nu_grid,
+                       nu_f_lim=None, nu_k_lim=None)
+
+    assert out.attrs["mode"] == "sparse"
+    k = out["wavenumber"].values
+    k_peak = k[np.nanargmax(out["wavenumber_spectrum"].values)]
+    assert abs(k_peak - k0) / k0 < 0.2
+
+
+def test_sparse_collinear_raises():
+    """A collinear array cannot form a two-dimensional aperture."""
+    t = np.arange(0, 256, 0.25)
+    px = np.array([0.0, 1.0, 2.0, 3.0])
+    py = np.zeros_like(px)
+    elev = np.stack([np.cos(0.1 * x + t) for x in px], axis=-1)
+    spec = MultiApertureArrays.from_numpy(
+        time=t, surface_elevation=elev, position_x=px, position_y=py,
+        depth=100.0, fs=4.0)
+    with pytest.raises(ValueError):
+        spec.compute(freqs=FREQS)
+
+
+def test_sparse_apertures_nested():
+    """The sparse sub-apertures should be nested, coarse to tight, each with at
+    least three non-collinear elements."""
+    px, py = _ring_array()
+    t = np.arange(0, 64, 0.25)
+    elev = np.zeros((len(t), len(px)))
+    spec = MultiApertureArrays.from_numpy(
+        time=t, surface_elevation=elev, position_x=px, position_y=py,
+        depth=100.0, fs=4.0)
+    aps = spec._sparse_apertures()
+    assert len(aps) >= 2
+    bmax = []
+    for _, idx in aps:
+        assert len(idx) >= 3
+        sx, sy = px[idx], py[idx]
+        bmax.append(np.hypot(sx[:, None] - sx[None, :],
+                             sy[:, None] - sy[None, :]).max())
+    # coarse -> tight: the longest baseline shrinks from one aperture to the next
+    assert all(bmax[i] >= bmax[i + 1] for i in range(len(bmax) - 1))
+
+
+def test_sparse_lh_sign_with_slopes():
+    """Co-located slopes let the sparse path resolve the 180-degree ambiguity
+    through the Longuet-Higgins first moment."""
+    import xarray as xr
+    px, py = _ring_array()
+    f0, direction_deg, depth, fs = 0.12, 30.0, 100.0, 4.0
+    omega = 2 * np.pi * f0
+    k0 = _wavenumber(f0, depth)
+    theta = np.radians(direction_deg)
+    kx0, ky0 = k0 * np.cos(theta), k0 * np.sin(theta)
+    t = np.arange(int(256 * fs)) / fs
+    ph = kx0 * px[:, None] + ky0 * py[:, None] - omega * t[None, :]
+    elev = (0.4 * np.cos(ph)).T                       # (time, element)
+    se = (-0.4 * kx0 * np.sin(ph)).T                  # eastward slope
+    sn = (-0.4 * ky0 * np.sin(ph)).T                  # northward slope
+    ds = xr.Dataset(
+        data_vars={
+            "surface_elevation": (["time", "element"], elev),
+            "eastward_slope": (["time", "element"], se),
+            "northward_slope": (["time", "element"], sn),
+            "position_x": ("element", px),
+            "position_y": ("element", py),
+        },
+        coords={"time": t, "element": np.arange(len(px))},
+    )
+    spec = MultiApertureArrays.from_arrays(ds, depth=depth, fs=fs,
+                                           direction_convention="math")
+    k_grid = 2.0**np.linspace(np.log2(0.02), np.log2(1.0), 64)
+    nu_grid = 2.0**np.linspace(np.log2(0.02), np.log2(2.0), 64)
+    out = spec.compute(freqs=FREQS, k_grid=k_grid, nu_grid=nu_grid,
+                       nu_f_lim=None, nu_k_lim=None)
+    # the Longuet-Higgins reference is populated (sign path ran)
+    assert np.isfinite(out["lh_direction"].values).any()
+    # the peak-frequency direction lands in the planted hemisphere
+    fpk = np.nanargmax(out["frequency_spectrum"].values)
+    md = out["mean_direction"].values[fpk]
+    assert np.cos(np.radians(md - direction_deg)) > 0
+
+
+def test_sparse_reliability_gate():
+    """The reliability gate (default on) works through the sparse path and still
+    recovers the peak wavenumber."""
+    t, elev, px, py, k0, _ = _sparse_monochromatic()
+    spec = MultiApertureArrays.from_numpy(
+        time=t, surface_elevation=elev, position_x=px, position_y=py,
+        depth=100.0, fs=4.0)
+    k_grid = 2.0**np.linspace(np.log2(0.02), np.log2(1.0), 64)
+    nu_grid = 2.0**np.linspace(np.log2(0.02), np.log2(2.0), 64)
+    out = spec.compute(freqs=FREQS, k_grid=k_grid, nu_grid=nu_grid,
+                       nu_f_lim=None, nu_k_lim=None)   # default reliability_gate
+    k = out["wavenumber"].values
+    assert abs(k[np.nanargmax(out["wavenumber_spectrum"].values)] - k0) / k0 < 0.25
+
+
+def test_sign_anchor_flips_hemisphere():
+    """An external sign anchor pointing the other way must flip the reported
+    hemisphere by roughly 180 degrees."""
+    eta, _, _ = _monochromatic_field(direction_deg=40.0)
+    spec = MultiApertureArrays.from_field(eta, dx=1.0, depth=100.0, fs=4.0)
+    base = spec.compute(**DENSE)
+
+    fpk = np.nanargmax(base["frequency_spectrum"].values)
+    d0 = base["mean_direction"].values[fpk]
+
+    # anchor pointing 180 degrees away over the whole band, fully reliable
+    anchor = (FREQS, np.full_like(FREQS, (d0 + 180.0) % 360.0),
+              np.ones_like(FREQS))
+    flipped = spec.compute(sign_anchor=anchor, **DENSE)
+    d1 = flipped["mean_direction"].values[fpk]
+
+    sep = abs(((d1 - d0 + 180) % 360) - 180)
+    assert sep > 120.0
+
+
+def test_backward_compatibility_arrays():
+    """Adding the multi-aperture class must not disturb the existing Arrays
+    radial path."""
+    t = np.arange(0, 256, 0.25)
+    f0, omega = 0.2, 2 * np.pi * 0.2
+    k0 = omega**2 / GRAV
+    radius = 0.5 * (np.pi / k0) / 2
+    ang = np.radians(np.array([0, 72, 144, 216, 288]))
+    px = np.r_[0.0, radius * np.cos(ang)]
+    py = np.r_[0.0, radius * np.sin(ang)]
+    eta = np.stack([0.5 * np.cos(k0 * np.cos(0.7) * x + k0 * np.sin(0.7) * y
+                                 - omega * t) for x, y in zip(px, py)], axis=-1)
+    arr = ewdm.Arrays.from_numpy(time=t, surface_elevation=eta,
+                                 position_x=px, position_y=py, fs=4.0)
+    out = arr.compute(coordinate="wavenumber", omin=-4, omax=1, nvoice=8)
+    assert "wavenumber_spectrum" in out
+
+
+def test_auto_apertures_default_ladder():
+    """The default (no `apertures`) builds a data-aware ladder of coarse windows
+    down to tight crosses, spanning the field of view to near the pixel scale."""
+    from ewdm.multiaperture import auto_apertures
+    ny, nx, dx = 64, 64, 0.5
+    aps = auto_apertures(ny, nx, dx)
+    bl = [(2 * e[1] * dx if isinstance(e, tuple) else e * dx) for _, e in aps]
+    assert all(a > b for a, b in zip(bl, bl[1:]))            # coarse -> fine
+    assert not isinstance(aps[0][1], tuple)                  # coarsest is a window
+    assert bl[0] <= min(ny, nx) * dx                         # fits the field
+    assert bl[-1] <= 6 * dx                                  # tight high-k rung
+    assert any(isinstance(e, tuple) and e[0] == "plus" for _, e in aps)
+
+    # compute() with no apertures runs and the ladder reaches near the pixel scale
+    eta, k0, _ = _monochromatic_field(dx=dx, ny=ny, nx=nx)
+    out = MultiApertureArrays.from_field(eta, dx, depth=100.0, fs=4.0).compute(
+        seed=0, return_apertures=True)
+    assert out["aperture_khi"].values.max() > np.pi / (6 * dx)
+    k = out["wavenumber"].values
+    F = out["wavenumber_spectrum"].values
+    assert abs(k[np.nanargmax(F)] - k0) / k0 < 0.35         # peak still recovered


### PR DESCRIPTION
New feature request: "multiaperture" extension of Arrays() functionality to allow resolution of a wider range of scales. Motivating this development is the problem that with WDM (and EWDM) array-based processing, energy piles up right before the effective $k_{max}$ before falling right off a cliff:

<img width="2051" height="1471" alt="Screenshot from 2026-06-22 13-43-12" src="https://github.com/user-attachments/assets/a4d2bccf-6e7b-4af8-a7e0-1a1f8bfd633f" />

The fix: randomly-assorted virtual wave gauges which are seeded onto the water surface elevation fields obtained via stereophotogrammetry or polarimetric slope sensing, with each scale's sweet spot establishing the maximum array baseline size (the 'aperture'). Several such apertures are created dynamically and stitched together to give a consistent single spectrum which spans the low f/k to high f/k range permitted by the source elevation dataset. Below is an example (not included within the gallery, but associated with some of my polarimetric field observations):

<img width="2158" height="1264" alt="Screenshot from 2026-06-22 13-46-41" src="https://github.com/user-attachments/assets/528d102a-fc28-4cfb-814f-01548873c880" />

This extension improves not only fidelity in wavenumber space, but in directional estimation as well. Here are directional spreading functions obtained from the Guimaraes _et al._, (2020) stereo dataset via fixed (2 m diameter) array, multiaperture approach, and direct FFT:

<img width="2067" height="1755" alt="Screenshot from 2026-06-22 13-45-11" src="https://github.com/user-attachments/assets/40199a3a-51e3-4fb7-b60f-8f1249e5e48f" />
